### PR TITLE
Create users in admin view

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -44,6 +44,7 @@ var views = {
         sparql: require('./views/admin/sparql'),
         remotes: require('./views/admin/remotes'),
         users: require('./views/admin/users'),
+        newUser: require('./views/admin/newUser'),
         update: require('./views/admin/update'),
         jobs: require('./views/admin/jobs'),
         theme: require('./views/admin/theme'),
@@ -217,12 +218,14 @@ function App() {
     app.get('/admin/sparql', requireAdmin, views.admin.sparql);
     app.get('/admin/remotes', requireAdmin, views.admin.remotes);
     app.get('/admin/users', requireAdmin, views.admin.users);
+    app.get('/admin/newUser', requireAdmin, views.admin.newUser);
     app.get('/admin/update', requireAdmin, views.admin.update);
     app.get('/admin/theme', requireAdmin, views.admin.theme);
     app.post('/admin/theme', requireAdmin, uploadToMemory.single('logo'), views.admin.theme);
     app.get('/admin/backup', requireAdmin, views.admin.backup);
     app.post('/admin/backup', requireAdmin, bodyParser.urlencoded({ extended: true }), views.admin.backup);
     app.post('/admin/backup/restore/:prefix', requireAdmin, bodyParser.urlencoded({ extended: true }), views.admin.backupRestore);
+    app.post('/admin/newUser', requireAdmin, bodyParser.urlencoded({ extended: true }), views.admin.newUser);
     app.post('/admin/updateUser', requireAdmin, bodyParser.urlencoded({ extended: true }), actions.admin.updateUser);
     app.post('/admin/deleteUser', requireAdmin, bodyParser.urlencoded({ extended: true }), actions.admin.deleteUser);
 

--- a/lib/createUser.js
+++ b/lib/createUser.js
@@ -14,10 +14,6 @@ function createUser(info) {
     var graphUri = 
         config.get('databasePrefix') + util.createTriplestoreID(info.username)
 
-
-    console.log('creating user')
-    console.log(JSON.stringify(info))
-
     return db.model.User.findOrCreate({
 
         where: Sequelize.or({
@@ -42,13 +38,9 @@ function createUser(info) {
         const created = res[1]
 
         if(!created) {
-
             return Promise.reject(new Error('E-mail address or username already in use'))
-
         } else {
-
             return Promise.resolve(user)
-
         }
 
     })

--- a/lib/mail/createPassword.js
+++ b/lib/mail/createPassword.js
@@ -1,0 +1,18 @@
+const sendMail = require('./sendMail')
+const loadTemplate = require('../loadTemplate')
+const config = require('../config')
+
+function sendCreatePasswordMail(user, administrator) {
+
+    sendMail(user, 'Your SynBioHub Account', loadTemplate('mail/resetPassword.txt', {
+
+        link: config.get('instanceUrl') + 'resetPassword/token/' + user.resetPasswordLink,
+        administrator: administrator.name,
+        username: user.username,
+
+    }))
+
+}
+
+module.exports = sendCreatePasswordMail
+

--- a/lib/views/admin/newUser.js
+++ b/lib/views/admin/newUser.js
@@ -1,0 +1,73 @@
+
+const pug = require('pug');
+const config = require('../../config');
+const createUser = require('../../createUser');
+const sendCreatePasswordMail = require('../../mail/createPassword')
+var extend = require('xtend');
+const uuidV4 = require('uuid/v4');
+var sha1 = require('sha1')
+
+module.exports = function(req, res) {
+    if(req.method === 'POST') {
+        post(req, res)
+    } else {
+        form(req, res, {})
+    }
+}
+
+
+function form(req, res, locals) {
+
+	locals = extend({
+        config: config.get(),
+        section: 'admin',
+        adminSection: 'theme',
+        user: req.user,
+        form: locals.form || {}
+    }, locals);
+	
+    res.send(pug.renderFile('templates/views/admin/newUser.jade', locals))
+}
+
+function post(req, res) {
+    if(!req.body.name) {
+        return form(req, res, {
+            form: req.body,
+            registerAlert: 'Please enter the user\'s name'
+        })
+    }
+
+    if(!req.body.email) {
+        return form(req, res, {
+            form: req.body,
+            registerAlert: 'Please enter the user\'s email'
+        })
+    }
+
+    if(!req.body.username) {
+        return form(req,res, {
+            form: req.body,
+            registerAlert: 'Please enter the desired username'
+        })
+    }
+
+    createUser({
+        name: req.body.name,
+        email: req.body.email,
+        username: req.body.username,
+        affiliation: req.body.affiliation,
+        password: uuidV4(),
+        isAdmin: req.body.isAdmin !== undefined
+    }).then((user) => {
+        user.resetPasswordLink = sha1(uuidV4())
+
+        return user.save()
+    }).then((user) => {
+        sendCreatePasswordMail(user, req.user)
+
+        res.redirect('/admin/users/');
+    })
+}
+
+
+

--- a/lib/views/admin/users.js
+++ b/lib/views/admin/users.js
@@ -16,7 +16,8 @@ module.exports = function(req, res) {
             section: 'admin',
             adminSection: 'users',
             user: req.user,
-            users: users
+            users: users,
+            canSendEmail: config.get('mail').sendgridApiKey != ""
         }
 
         res.send(pug.renderFile('templates/views/admin/users.jade', locals))

--- a/lib/views/register.js
+++ b/lib/views/register.js
@@ -13,23 +13,16 @@ var db = require('../db')
 module.exports = function(req, res) {
     
     if(req.method === 'POST') {
-
         registerPost(req, res)
-
     } else {
-
         registerForm(req, res, {})
-
     }
-    
 }
 
 function registerForm(req, res, locals) {
 
 	if (req.user) {
-
 		return res.redirect(req.query.next || '/');
-
 	}
 
     locals = extend({

--- a/lib/views/resetPassword.js
+++ b/lib/views/resetPassword.js
@@ -8,7 +8,7 @@ var config = require('../config')
 var db = require('../db')
 
 var sha1 = require('sha1')
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 
 var sendResetPasswordMail = require('../mail/resetPassword')
 

--- a/lib/views/submit.js
+++ b/lib/views/submit.js
@@ -15,7 +15,7 @@ var SBOLDocument = require('sboljs')
 
 var extend = require('xtend')
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var serializeSBOL = require('../serializeSBOL')
 

--- a/mail/createPassword.txt
+++ b/mail/createPassword.txt
@@ -1,0 +1,12 @@
+Hi,
+
+$administrator has created an account for you on an instance of SynBioHub.
+
+Your username is: $username
+
+Your password has not been set. To set up your password, follow this link:
+
+    $link
+
+If you did not request an account, please ignore this e-mail.
+

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "multimap": "^1.0.2",
     "multiparty": "^4.1.3",
     "mz": "^2.6.0",
-    "node-uuid": "^1.4.7",
     "npool": "^1.4.7",
     "pg-escape": "^0.2.0",
     "pug": "^0.1.0",

--- a/templates/views/admin/newUser.jade
+++ b/templates/views/admin/newUser.jade
@@ -1,0 +1,44 @@
+
+extends ../../layouts/admin.jade
+
+block adminContent
+    div.row
+        div.col-md-12
+            h1 Create an Account
+    
+    div.row
+        div.col-md-12
+            p The user will be emailed their login details upon account creation.
+
+    div.row
+        div.col-md-12
+            if registerAlert
+                div.alert.alert-danger #{registerAlert}
+
+            form(accept-charset='UTF-8',action='newUser',method='post')
+                
+                input.text(name='utf8',type='hidden',value='✓')
+
+                div.form-group
+                    label(for='name') Full Name
+                    input.form-control(name='name', id='name', type='text', autocomplete='off', value=form.name)
+
+                div.form-group
+                    label(for='affiliation') Affiliation (optional)
+                    input.form-control(name='affiliation', id='affiliation', autocomplete='off', value=form.affiliation)
+
+                div.form-group
+                    label(for='email') Email
+                    input.form-control(name='email', id='email', type='email', autocomplete='off', value=form.email)
+
+                div.form-group
+                    label(for='username') Username
+                    input.form-control(name='username', id='username', type='username', autocomplete='off', value=form.username)
+
+                div.checkbox
+                    label.form-check-label
+                        input(name='isAdmin', type='checkbox', value=form.isAdmin)
+                        | Grant Administrative Privileges
+
+                div
+                    input(type='submit',class='btn btn-primary',value='Create')

--- a/templates/views/admin/users.jade
+++ b/templates/views/admin/users.jade
@@ -2,6 +2,10 @@
 extends ../../layouts/admin.jade
 
 block adminContent
+    if(canSendEmail)
+        a.btn.btn-primary.pull-right(href="/admin/newUser") Create User
+        br
+        br
     table.table.table-striped.sbh-datatable
         thead
             tr


### PR DESCRIPTION
Added in functionality to create users in the administrator view. 

The administrator doesn't create a user password, but the user gets an email to set up a new password.

The functionality is disabled if there is not a SendGrid API key. (I checked it with my own SG key, so I do know it works.)