### PR TITLE
Changed run command to output log to synbiohub.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then install the SynBioHub dependencies with npm:
 
 Then run synbiohub:
 
-    node synbiohub.js
+    npm start
 
 
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "npm": ">=1.3.14"
   },
   "scripts": {
-    "start": "node synbiohub.js"
+    "start": "nodemon synbiohub.js | tee synbiohub.log"
   },
   "main": "synbiohub.js"
 }


### PR DESCRIPTION
Addresses issue #202 
Will require changing the way that SynBioHub is started, instead of `forever synbiohub` or `nodemon synbiohub` or `node synbiohub`, use `npm start`.
