### PR TITLE
Add run commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "npm": ">=1.3.14"
   },
   "scripts": {
-     "start": "forever synbiohub.js | tee synbiohub.log"
+     "start": "forever synbiohub.js | tee synbiohub.log",
+     "dev": "nodemon synbiohub.js | tee synbiohub.log"
   },
   "main": "synbiohub.js"
 }


### PR DESCRIPTION
Run for deployment with `npm start`, run for development with `npm run-script dev`! Addresses issue #201 because both create logs