### PR TITLE
Search all top-levels, not just SBOL

### DIFF
--- a/sparql/search.sparql
+++ b/sparql/search.sparql
@@ -13,27 +13,12 @@ SELECT DISTINCT
     ?name
     ?description
     ?type
-    (COUNT(DISTINCT ?user) as ?uses)
+    (COUNT(DISTINCT ?use) as ?uses)
 WHERE {
     $criteria
 
-    OPTIONAL { 
-        { 
-            ?use sbol2:definition ?subject .    
-            { ?user sbol2:module ?use } UNION 
-            { ?user sbol2:component ?use } UNION 
-            { ?user sbol2:functionalComponent ?use } 
-        } UNION 
-        { ?user sbol2:model ?subject} UNION 
-        { ?user sbol2:sequence ?subject } . 
-    }
-
-    { ?subject a sbol2:ComponentDefinition } UNION 
-    { ?subject a sbol2:ModuleDefinition } UNION 
-    { ?subject a sbol2:Collection } UNION 
-    { ?subject a sbol2:Sequence } UNION 
-    { ?subject a sbol2:Model } .
     ?subject a ?type
+    OPTIONAL { ?use ?p ?subject . }
     OPTIONAL { ?subject sbol2:displayId ?displayId . }
     OPTIONAL { ?subject sbol2:version ?version . }
     OPTIONAL { ?subject dcterms:title ?name . }


### PR DESCRIPTION
I've tested this and it appears to work and does not significantly decrease speed of the query. 