### PR TITLE
Update administrator email 

### DIFF
--- a/lib/actions/admin/federate.js
+++ b/lib/actions/admin/federate.js
@@ -7,7 +7,7 @@ module.exports = function (req, res) {
         uriPrefix: config.get('databasePrefix'),
         administratorEmail: req.body.administratorEmail,
         updateEndpoint: 'updateWebOfRegistries',
-        name: config.get('instanceUrl'),
+        name: config.get('instanceName'),
         description: config.get('frontPageText')
     }
 

--- a/lib/actions/admin/federate.js
+++ b/lib/actions/admin/federate.js
@@ -5,14 +5,15 @@ module.exports = function (req, res) {
     let data = {
         instanceUrl: config.get('instanceUrl'),
         uriPrefix: config.get('databasePrefix'),
-        administratorEmail: config.get('administratorEmail'),
+        administratorEmail: req.body.administratorEmail,
         updateEndpoint: 'updateWebOfRegistries',
         name: config.get('instanceUrl'),
         description: config.get('frontPageText')
     }
 
+    config.set('administratorEmail', req.body.administratorEmail);
+    
     let worUrl = req.body.webOfRegistries[-1] != "/" ? req.body.webOfRegistries : req.body.webOfRegistries.substring(0, -1);
-
 
     request.post(worUrl + "/instances/new/", {
         json: data

--- a/lib/actions/admin/federate.js
+++ b/lib/actions/admin/federate.js
@@ -26,7 +26,7 @@ module.exports = function (req, res) {
             res.redirect('/admin/registries');
         } else {
             config.set('webOfRegistriesSecret', body["updateSecret"]);
-            config.set('webOfRegistriesUrl', req.body.webOfRegistries);
+            config.set('webOfRegistriesUrl', worUrl);
             config.set('webOfRegistriesId', body["id"]);
 
             res.redirect('/admin/registries');

--- a/lib/actions/admin/updateAdministratorEmail.js
+++ b/lib/actions/admin/updateAdministratorEmail.js
@@ -1,0 +1,15 @@
+
+const config = require('../../config');
+const updateWor = require('./updateWor');
+
+module.exports = function(req, res) {
+
+    if(req.body.administratorEmail) {
+        config.set("administratorEmail", req.body.administratorEmail);
+
+        res.redirect('/admin/registries');
+
+        updateWor();
+    }
+}
+

--- a/lib/actions/admin/updateAdministratorEmail.js
+++ b/lib/actions/admin/updateAdministratorEmail.js
@@ -6,10 +6,10 @@ module.exports = function(req, res) {
 
     if(req.body.administratorEmail) {
         config.set("administratorEmail", req.body.administratorEmail);
+        
+        updateWor();
 
         res.redirect('/admin/registries');
-
-        updateWor();
     }
 }
 

--- a/lib/actions/admin/updateUser.js
+++ b/lib/actions/admin/updateUser.js
@@ -14,10 +14,6 @@ module.exports = function(req, res) {
         user.isCurator = req.body.isCurator
         user.isAdmin = req.body.isAdmin
 
-        if(req.body.isMaintainer) {
-            config.set('administratorEmail', req.body.email);
-        }
-
         return user.save()
 
     }).then(() => {

--- a/lib/actions/admin/updateWor.js
+++ b/lib/actions/admin/updateWor.js
@@ -4,7 +4,7 @@ const request = require('request')
 module.exports = function () {
     let data = {
         administratorEmail: config.get('administratorEmail'),
-        name: config.get('instanceUrl'),
+        name: config.get('instanceName'),
         description: config.get('frontPageText')
     }
     

--- a/lib/actions/admin/updateWor.js
+++ b/lib/actions/admin/updateWor.js
@@ -8,9 +8,11 @@ module.exports = function () {
         description: config.get('frontPageText')
     }
     
-    let worUrl = req.body.webOfRegistries[-1] != "/" ? req.body.webOfRegistries : req.body.webOfRegistries.substring(0, -1);
+    let worUrl = config.get('webOfRegistriesUrl');
     let updateSecret = config.get('webOfRegistriesSecret');
     let id = config.get('webOfRegistriesId');
+
+    data.updateSecret = updateSecret;
 
     request.patch(worUrl + "/instances/" + id + "/", {
         json: data

--- a/lib/actions/admin/updateWor.js
+++ b/lib/actions/admin/updateWor.js
@@ -1,0 +1,25 @@
+const config = require('../../config')
+const request = require('request')
+
+module.exports = function () {
+    let data = {
+        administratorEmail: config.get('administratorEmail'),
+        name: config.get('instanceUrl'),
+        description: config.get('frontPageText')
+    }
+    
+    let worUrl = req.body.webOfRegistries[-1] != "/" ? req.body.webOfRegistries : req.body.webOfRegistries.substring(0, -1);
+    let updateSecret = config.get('webOfRegistriesSecret');
+    let id = config.get('webOfRegistriesId');
+
+    request.patch(worUrl + "/instances/" + id + "/", {
+        json: data
+    }, (err, resp, body) => {
+        if (err) {
+            console.log("Update error");
+            console.log(err);
+        } else {
+            res.redirect('/admin/registries');
+        }
+    });
+}

--- a/lib/actions/admin/updateWor.js
+++ b/lib/actions/admin/updateWor.js
@@ -14,12 +14,16 @@ module.exports = function () {
 
     data.updateSecret = updateSecret;
 
+    console.log(data);
+
     request.patch(worUrl + "/instances/" + id + "/", {
         json: data
     }, (err, resp, body) => {
         if (err) {
             console.log("Update error");
             console.log(err);
+        } else {
+            config.set('webOfRegistriesSecret', body["updateSecret"]);
         }
     });
 }

--- a/lib/actions/admin/updateWor.js
+++ b/lib/actions/admin/updateWor.js
@@ -20,8 +20,6 @@ module.exports = function () {
         if (err) {
             console.log("Update error");
             console.log(err);
-        } else {
-            res.redirect('/admin/registries');
         }
     });
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -101,7 +101,8 @@ var actions = {
         updateUser: require('./actions/admin/updateUser'),
         deleteUser: require('./actions/admin/deleteUser'),
         federate: require('./actions/admin/federate'),
-        retrieve: require('./actions/admin/retrieveFromWoR')
+        retrieve: require('./actions/admin/retrieveFromWoR'),
+        setAdministratorEmail: require('./actions/admin/updateAdministratorEmail')
     }
 }
 
@@ -259,6 +260,7 @@ function App() {
     app.post('/admin/deleteRegistry', requireAdmin, bodyParser.urlencoded({ extended: true }), actions.admin.deleteRegistry);
     app.get('/admin/mail', requireAdmin, views.admin.mail);
     app.post('/admin/mail', requireAdmin, bodyParser.urlencoded({ extended: true }), views.admin.mail);
+    app.post('/admin/setAdministratorEmail', requireAdmin, bodyParser.urlencoded({ extended: true }), actions.admin.setAdministratorEmail);
 
     app.post('/updateWebOfRegistries', bodyParser.json(), api.updateWebOfRegistries);
     app.post('/admin/federate', requireAdmin, bodyParser.urlencoded({ extended: true }), actions.admin.federate);

--- a/lib/views/admin/registries.js
+++ b/lib/views/admin/registries.js
@@ -39,10 +39,6 @@ module.exports = function (req, res) {
         errors.push('The instance URI prefix is not set, this can be done from the admin dashboard.');
     }
 
-    if (federationData.administratorEmail === undefined) {
-        errors.push('The administrator email is not set, this can be done from the admin dashboard.');
-    }
-
     if (federationData.updateEndpoint === undefined) {
         errors.push('The update endpoint is not set, you likely need to upgrade your SynBioHub instance.');
     }

--- a/lib/views/admin/registries.js
+++ b/lib/views/admin/registries.js
@@ -70,7 +70,6 @@ module.exports = function (req, res) {
                 unregistered(req, res, errors);
             } else {
                 body = JSON.parse(body);
-                console.log("eMAIL: " + body.administratorEmail)
 
                 var locals = {
                     config: config.get(),

--- a/lib/views/admin/theme.js
+++ b/lib/views/admin/theme.js
@@ -1,11 +1,9 @@
 
-const pug = require('pug')
-
-const config = require('../../config')
-
-const theme = require('../../theme')
-
-const updateLogo = require('../../actions/admin/updateLogo')
+const pug = require('pug');
+const config = require('../../config');
+const theme = require('../../theme');
+const updateLogo = require('../../actions/admin/updateLogo');
+const updateWor = require('../../actions/admin/updateWor');
 
 module.exports = function(req, res) {
     if(req.method === 'POST') {
@@ -69,12 +67,20 @@ function post(req, res) {
 
     config.set(localConfig)
 
+    let publishUpdate = false;
+
     if(req.body.frontPageText != config.get('frontPageText')) {
         config.set('frontPageText', req.body.frontPageText)
+        publishUpdate = true;
     }
 
     if(req.body.instanceName != config.get('instanceName')) {
         config.set('instanceName', req.body.instanceName)
+        publishUpdate = true;
+    }
+
+    if(publishUpdate) {
+        updateWor();
     }
 
     if(req.file) {

--- a/templates/views/admin/registries.jade
+++ b/templates/views/admin/registries.jade
@@ -63,8 +63,10 @@ block adminContent
                         span &nbsp;&nbsp; #{error}
             else 
                 form(method="POST", action="federate")
-                    div.col-sm-8
+                    div.col-sm-4
                         input.form-control(type="text", name="webOfRegistries", placeholder="Web of Registries URL", value=config.webOfRegistriesUrl)
+                    div.col-sm-4
+                        input.form-control(type="text", name="administratorEmail", placeholder="Administrator Email", value=config.administratorEmail)
                     div.col-sm-4
                         input.btn.btn-primary.btn-block(type="submit", value="Submit") 
     hr

--- a/templates/views/admin/registries.jade
+++ b/templates/views/admin/registries.jade
@@ -27,16 +27,16 @@ block adminContent
     div.row
         if(registered)
             if(approved) 
-                div.col-sm-4
+                div.col-sm-6
                     div.alert.alert-success
                         span.fa.fa-check-circle-o
                         span &nbsp; #{config.instanceName} is part of the Web of Registries
             else
-                div.col-sm-4
+                div.col-sm-6
                     div.alert.alert-info
                         span.fa.fa-clock-o
                         span &nbsp; #{config.instanceName} pending approval by the Web of Registries Administrator
-            div.col-sm-4
+            div.col-sm-6
                 if(updateWorking)
                     div.alert.alert-success
                         span.fa.fa-globe
@@ -45,11 +45,19 @@ block adminContent
                     div.alert.alert-danger
                         span.fa.fa-ban
                         span &nbsp; The Web of Registries cannot update #{config.instanceName}
+
+            form.form(action="setAdministratorEmail", method="POST")
+                div.col-sm-4
+                    input.form-control(type="text", name="administratorEmail", placeholder="AdministratorEmail", value=config.administratorEmail)
+                div.col-sm-4
+                    button.btn.btn-block.btn-info(type="submit")
+                        span.fa.fa-pencil
+                        span &nbsp; Edit Entry
             div.col-sm-4
                 input#worUrl(type="hidden", value=wor)
                 input#worId(type="hidden", value=worId)
                 input#worSecret(type="hidden", value=secret)
-                button.removeFromWoR.btn.btn-block.btn-lg.btn-danger 
+                button.removeFromWoR.btn.btn-block.btn-danger 
                     span.fa.fa-trash
                     span &nbsp; Delete Entry
                     

--- a/templates/views/admin/registries.jade
+++ b/templates/views/admin/registries.jade
@@ -48,7 +48,7 @@ block adminContent
 
             form.form(action="setAdministratorEmail", method="POST")
                 div.col-sm-4
-                    input.form-control(type="text", name="administratorEmail", placeholder="AdministratorEmail", value=config.administratorEmail)
+                    input.form-control(type="text", name="administratorEmail", placeholder="Administrator Email", value=config.administratorEmail)
                 div.col-sm-4
                     button.btn.btn-block.btn-info(type="submit")
                         span.fa.fa-pencil

--- a/templates/views/admin/users.jade
+++ b/templates/views/admin/users.jade
@@ -17,7 +17,6 @@ block adminContent
                 th Member
                 th Curator
                 th Admin
-                th Maintainer
                 th
                 th
         tbody
@@ -41,8 +40,6 @@ block adminContent
                         input(type='checkbox',checked=u.isCurator)
                     td
                         input(type='checkbox',checked=u.isAdmin)
-                    td
-                        input(type='checkbox',checked=(u.email==config.administratorEmail))
                     td
                         button.btn.btn-success.save Save
                     td


### PR DESCRIPTION
This PR: 
- Removes the previous maintainer option from the User dashboard
- Adds a required Administrator Email to the registry registration form
- Adds the ability to modify the administrator email after WoR registration
- Updates the web of registries upon name or description change in the Theme dashboard