### PR TITLE
Don't assume accept header is present

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -435,21 +435,16 @@ function App() {
     app.post('/sparql', bodyParser.urlencoded({ extended: true }), sparql)
 
     function sparql(req, res) {
-
         // jena sends accept: */* and then complains when we send HTML
         // back. so only send html if the literal string text/html is present
         // in the accept header.
-        //
-        if (req.header('accept').indexOf('text/html') !== -1) {
-
+        
+        let accept = req.header('accept');
+        if (accept && accept.indexOf('text/html') !== -1) {
             views.sparql(req, res)
-
         } else {
-
             api.sparql(req, res)
-
         }
-
     }
 
     function requireUser(req, res, next) {


### PR DESCRIPTION
Some tools (golang http stdlib) don't send 'Accept: */*', so
default to the api endpoint if it's not there.