### PR TITLE
A new look for the view pages

### DIFF
--- a/public/styles/site/synbiohub.less
+++ b/public/styles/site/synbiohub.less
@@ -85,7 +85,7 @@ a {
 }
 
 .entry-actions .btn {
-    width: 200px;
+    width: 40px;
     text-align: left;
 }
 
@@ -93,6 +93,34 @@ a {
     text-align: left;
 }
 
+.dropdown-menu li:hover .sub-menu {
+  visibility: visible;
+}
+
+.dropdown:hover .dropdown-menu {
+  display: block;
+  margin-top: 0;
+}
+
+.dropdown-menu .sub-menu {
+  left: 100%;
+  position: absolute;
+  top: 0;
+  visibility: hidden;
+  margin-top: -1px;
+}
+
+.panel-heading .accordion-toggle:after {
+    /* symbol for "opening" panels */
+    font-family: 'Glyphicons Halflings';  /* essential for enabling glyphicon */
+    content: "\e114";    /* adjust as needed, taken from bootstrap.css */
+    float: right;        /* adjust as needed */
+    color: grey;         /* adjust as needed */
+}
+.panel-heading .accordion-toggle.collapsed:after {
+    /* symbol for "collapsed" panels */
+    content: "\e080";    /* adjust as needed, taken from bootstrap.css */
+}
 
 .main-search-form input {
     background-color: #ECF0F1;

--- a/templates/layouts/topLevel.jade
+++ b/templates/layouts/topLevel.jade
@@ -33,7 +33,7 @@ block content
     div.submission-detail.container-fluid
 
         div.row.entry-heading
-            div.col-sm-5.entry-title
+            div.col-sm-6.entry-title
                 h1 #{meta.name?meta.name:meta.id} 
                     if meta.sbhBookmark && meta.sbhBookmark.description == 'true'
                         a(href='http://wiki.synbiohub.org/Terms/synbiohub#bookmark',title='Bookmarked Parts')
@@ -72,11 +72,11 @@ block content
                         | as a replacement.
 
             if (collectionIcon)
-                div.col-sm-3.sbh-collection-icon
+                div.col-sm-6.sbh-collection-icon
                     img(src=collectionIcon)
 
         div.row
-            div.col-md-8
+            div.col-md-11
 
                 if meta.wasDerivedFrom && meta.wasDerivedFrom != ''
                     h5 Source: 
@@ -108,166 +108,174 @@ block content
 
                 block topLevelBelowTitle
 
-                table.table.table-striped.entry-detail-table
-
-                    if meta.labels && meta.labels.length > 0
-                        tr
-                            td Labels
-                            td #{meta.labels.join(', ')}
-
-                    if meta.types && meta.types.length > 0
-                        tr
-                            td Types
-                            td 
-                                for type in meta.types
-                                    if type.description 
-                                       != type.description.name
-                                       a(href=type.term,title='Learn more about this type') 
-                                           span.fa.fa-info-circle
-                                       a(href='/search/type=<'+encodeURIComponent(type.uri)+'>&',title='Find all records with this type') 
-                                           span.fa.fa-search
-                                    else 
-                                       != type.uri 
-                                       a(href=type.uri,title='Learn more about this type') 
-                                           span.fa.fa-info-circle
-                                       a(href='/search/type=<'+encodeURIComponent(type.uri)+'>&',title='Find all records with this type') 
-                                           span.fa.fa-search
-                                    br
-
-                    if meta.roles && meta.roles.length > 0
-                        tr
-                            td Roles
-                            td
-                                for role in meta.roles
-                                    if role.description
-                                        != role.description.name
-                                        a(href=role.term,title='Learn more about this role') 
-                                            span.fa.fa-info-circle
-                                        a(href='/search/role=<'+encodeURIComponent(role.uri)+'>&',title='Find all records with this role') 
-                                            span.fa.fa-search
-                                    else 
-                                        != role.term 
-                                        a(href=role.uri,title='Learn more about this role') 
-                                            span.fa.fa-info-circle
-                                        a(href='/search/role=<'+encodeURIComponent(role.uri)+'>&',title='Find all records with this role') 
-                                            span.fa.fa-search
-                                    br
-
-                    block topLevelPropertyTable
-
-                block topLevelBelowPropertyTable
-
-            div.col-md-4.entry-actions
-                if (rdfType.name != 'Collection' || memberCount <= 10000)
-                    a.btn.btn-primary(href=meta.url + '/' + meta.id + '.xml')
-                        span.fa.fa-download
-                        |  Download SBOL File
-                    br
-                    br
-                if rdfType.name == 'Component'
-                    a.btn.btn-primary(href=meta.url + '/' + meta.id + '.gb')
-                        span.fa.fa-download
-                        |  Download GenBank
-                    br
-                    br
-                if rdfType.name == 'Component' || rdfType.name == 'Sequence'
-                    a.btn.btn-primary(href=meta.url + '/' + meta.id + '.fasta')
-                        span.fa.fa-download
-                        |  Download FASTA
-                    br
-                    br
-                if rdfType.name == 'Component'
-                    a.btn.btn-primary.sbh-download-picture
-                        span.fa.fa-picture-o
-                        |  Download Image
-                    br
-                    br
-                if !meta.remote && rdfType.name != 'Collection'
-                    a.btn.btn-primary(href=meta.url + '/uses',title='Find all uses of this '+rdfType.name)
+        div.row
+           if (rdfType.name != 'Collection' || memberCount <= 10000)
+                li.dropdown.btn.btn-primary
+                    span.fa.fa-download
+                        |  
+                        span.caret
+                    ul.dropdown-menu.dropdown-toggle
+                        li
+                            a(href=meta.url + '/' + meta.id + '.xml') Download SBOL File
+                        if rdfType.name == 'Component'
+                            li 
+                                a(href=meta.url + '/' + meta.id + '.gb') Download GenBank
+                        if rdfType.name == 'Component' || rdfType.name == 'Sequence'
+                            li 
+                                a(href=meta.url + '/' + meta.id + '.fasta') Downloand FASTA
+                        if rdfType.name == 'Component'
+                            li 
+                                a.sbh-download-picture Download Image
+                        if rdfType.name == 'Attachment'
+                            li 
+                                a(href=meta.url + '/download') Downloand Attachment
+           if !meta.remote && rdfType.name != 'Collection' && rdfType.name != 'Component'
+               li.dropdown.btn.btn-primary
+                    a(href=meta.url + '/uses',title='Find all uses of this '+rdfType.name,style="color:white")
                         span.fa.fa-search
-                        |  Find Uses
-                    br
-                    br
-                block topLevelButtons
-                if meta.triplestore != 'public'
-                    a.btn.btn-success(onclick="popup()")
+                        |  
+           block topLevelButtons
+           if meta.triplestore != 'public'
+               li.btn.btn-success
+                    a(onclick="popup()",title='Share',style="color:white")
                         span.fa.fa-share
-                        |  Share
-                    br
-                    br
-                if meta.triplestore != 'public' && locals.user && locals.user.isCurator
-                    a.btn.btn-success(href=meta.url + '/makePublic')
+           if meta.triplestore != 'public' && locals.user && locals.user.isCurator
+               li.btn.btn-success
+                    a(href=meta.url + '/makePublic',title='Make Public',style="color:white")
                         span.fa.fa-unlock
-                        |  Make Public
-                    br
-                    br
-                if canEdit && meta.triplestore != 'public' && (rdfType.name != 'Collection')
-                    a.btn.btn-success(href=meta.url + '/remove')
+           if canEdit && meta.triplestore != 'public' && (rdfType.name != 'Collection')
+               li.btn.btn-success
+                    a(href=meta.url + '/remove',title='Remove',style="color:white")
                         span.fa.fa-remove
-                        |  Remove
-                    br
-                    br
-                if canEdit
-                    a.btn.btn-info(href=meta.url + "/addOwner")
+           if canEdit
+               li.btn.btn-info
+                    a(href=meta.url + "/addOwner",title='Add Owner',style="color:white")
                         span.fa.fa-id-card
-                        |  Add owner
-                    br
-                    br
+           br
+           br
 
         block topLevelPreview
 
-        +mutable-description(meta.mutableDescriptionSource, meta.mutableDescription, canEdit)
-        +mutable-notes(meta.mutableNotesSource, meta.mutableNotes, canEdit)
-        +mutable-source(meta.sourceSource, meta.source, canEdit)
-        +citations(citationsSource, submissionCitations, canEdit) 
-				    
-        if collections.length > 0
-            div.row.entry-heading
-                div.col-sm-5.entry-title
-                    | <h3>Member of these Collections</h3>
+        .container
+            #accordion.panel-group
+                .panel.panel-default
+                    .panel-heading
+                        h4.panel-title
+                            a.accordion-toggle(data-toggle='collapse', href='#collapseZero')
+                                | <b>Details</b>
+                    #collapseZero.panel-collapse.collapse.in
+                        .panel-body
+                            table.table.table-striped.entry-detail-table
 
-            div.row
-                div.col-md-8
-                    table.table.table-striped.entry-detail-table
-                        tr
-                            td
-                                for collection in collections
-                                    a(href=collection.url,title=collection.name) #{collection.name} &nbsp;
-                                        a(href='/search/collection=<'+encodeURIComponent(collection.uri)+'>&',title='Find all records in this collection')
-                                            span.fa.fa-search
-                                    br
+                                if meta.labels && meta.labels.length > 0
+                                    tr
+                                        td Labels
+                                        td #{meta.labels.join(', ')}
 
-        if annotations && annotations.length > 0
-            div.row.entry-heading
-                div.col-sm-5.entry-title
-                    | <h3>Other Properties</h3>
+                                if meta.types && meta.types.length > 0
+                                    tr
+                                        td Types
+                                        td 
+                                            for type in meta.types
+                                                if type.description 
+                                                   != type.description.name
+                                                   a(href=type.term,title='Learn more about this type') 
+                                                       span.fa.fa-info-circle
+                                                   a(href='/search/type=<'+encodeURIComponent(type.uri)+'>&',title='Find all records with this type') 
+                                                       span.fa.fa-search
+                                                else 
+                                                   != type.uri 
+                                                   a(href=type.uri,title='Learn more about this type') 
+                                                       span.fa.fa-info-circle
+                                                   a(href='/search/type=<'+encodeURIComponent(type.uri)+'>&',title='Find all records with this type') 
+                                                       span.fa.fa-search
+                                                br
 
-            div.row
-                div.col-md-8
-                    table.table.table-striped.entry-detail-table
-                        for annotation in annotations
-                            tr
-                                td #{annotation.name}
-                                    a(href=annotation.nameDef,title='Learn more about this annotation type') 
-                                       span.fa.fa-info-circle
-                                if (annotation.type === 'uri')
-                                    td #{annotation.value}
-                                        a(href=annotation.url,title='Learn more about this annotation value') 
-                                            span.fa.fa-info-circle &nbsp;
-                                        a(href = '/search/<' + encodeURIComponent(annotation.nameDef) + '>=<' + encodeURIComponent(annotation.uri) + '>&', title = 'Find all records with this annotation')
-                                            span.fa.fa-search
-                                        if(annotation.removeOwner)
-                                            form.form-inline(style="display: inline" method='POST', action=annotation.removeOwner)
-                                                input(type='hidden' name='userUri' value=config.databasePrefix + annotation.value)
-                                                button.fakelink(type='submit')
-                                                    | &nbsp;
-                                                    span.fa.fa-trash
-                                else 
-                                    td #{annotation.value.toString()} &nbsp;
-                                        a(href = '/search/<' + encodeURIComponent(annotation.nameDef) + '>=' + encodeURIComponent('\''+annotation.value.replace('\'','\\\'')+'\'') + '&', title = 'Find all records with this annotation')
-                                            span.fa.fa-search
+                                if meta.roles && meta.roles.length > 0
+                                    tr
+                                        td Roles
+                                        td
+                                            for role in meta.roles
+                                                if role.description
+                                                    != role.description.name
+                                                    a(href=role.term,title='Learn more about this role') 
+                                                        span.fa.fa-info-circle
+                                                    a(href='/search/role=<'+encodeURIComponent(role.uri)+'>&',title='Find all records with this role') 
+                                                        span.fa.fa-search
+                                                else 
+                                                    != role.term 
+                                                    a(href=role.uri,title='Learn more about this role') 
+                                                        span.fa.fa-info-circle
+                                                    a(href='/search/role=<'+encodeURIComponent(role.uri)+'>&',title='Find all records with this role') 
+                                                        span.fa.fa-search
+                                                br
+
+                                block topLevelPropertyTable
+
+                            block topLevelBelowPropertyTable
+                            +mutable-description(meta.mutableDescriptionSource, meta.mutableDescription, canEdit)
+                            +mutable-notes(meta.mutableNotesSource, meta.mutableNotes, canEdit)
+                            +mutable-source(meta.sourceSource, meta.source, canEdit)
+                            +citations(citationsSource, submissionCitations, canEdit) 
+                if collections.length > 0
+                    .panel.panel-default
+                        .panel-heading
+                            h4.panel-title
+                                a.accordion-toggle(data-toggle='collapse', href='#collapseOne')
+                                    | <b>Member of these Collections</b>
+                        #collapseOne.panel-collapse.collapse
+                            .panel-body
+                                div.row
+                                    div.col-md-12
+                                        table.table.table-striped.entry-detail-table
+                                            tr
+                                                td
+                                                    for collection in collections
+                                                        a(href=collection.url,title=collection.name) #{collection.name} &nbsp;
+                                                            a(href='/search/collection=<'+encodeURIComponent(collection.uri)+'>&',title='Find all records in this collection')
+                                                                span.fa.fa-search
+                                                        br
+                if annotations && annotations.length > 0
+                    .panel.panel-default
+                        .panel-heading
+                            h4.panel-title
+                                a.accordion-toggle(data-toggle='collapse', href='#collapseTwo')
+                                    | <b>Other Properties</b>
+                        #collapseTwo.panel-collapse.collapse
+                            .panel-body
+                                div.row
+                                    div.col-md-12
+                                        table.table.table-striped.entry-detail-table
+                                            for annotation in annotations
+                                                tr
+                                                    td #{annotation.name}
+                                                        a(href=annotation.nameDef,title='Learn more about this annotation type') 
+                                                           span.fa.fa-info-circle
+                                                    if (annotation.type === 'uri')
+                                                        td #{annotation.value}
+                                                            a(href=annotation.url,title='Learn more about this annotation value') 
+                                                                span.fa.fa-info-circle &nbsp;
+                                                            a(href = '/search/<' + encodeURIComponent(annotation.nameDef) + '>=<' + encodeURIComponent(annotation.uri) + '>&', title = 'Find all records with this annotation')
+                                                                span.fa.fa-search
+                                                            if(annotation.removeOwner)
+                                                                form.form-inline(style="display: inline" method='POST', action=annotation.removeOwner)
+                                                                    input(type='hidden' name='userUri' value=config.databasePrefix + annotation.value)
+                                                                    button.fakelink(type='submit')
+                                                                        | &nbsp;
+                                                                        span.fa.fa-trash
+                                                    else 
+                                                        td #{annotation.value.toString()} &nbsp;
+                                                            a(href = '/search/<' + encodeURIComponent(annotation.nameDef) + '>=' + encodeURIComponent('\''+annotation.value.replace('\'','\\\'')+'\'') + '&', title = 'Find all records with this annotation')
+                                                                span.fa.fa-search
  
-        div.row
-            div.col-md-8
-                +attachments(meta.url, meta.attachments, canEdit)
+                .panel.panel-default
+                    .panel-heading
+                        h4.panel-title
+                            a.accordion-toggle(data-toggle='collapse', href='#collapseThree')
+                                | <b>Attachments</b>
+                    #collapseThree.panel-collapse.collapse
+                        .panel-body
+                            div.row
+                                div.col-md-12
+                                    +attachments(meta.url, meta.attachments, canEdit)
 

--- a/templates/layouts/topLevel.jade
+++ b/templates/layouts/topLevel.jade
@@ -109,50 +109,51 @@ block content
                 block topLevelBelowTitle
 
         div.row
-           if (rdfType.name != 'Collection' || memberCount <= 10000)
-                li.dropdown.btn.btn-primary
-                    span.fa.fa-download
-                        |  
-                        span.caret
-                    ul.dropdown-menu.dropdown-toggle
-                        li
-                            a(href=meta.url + '/' + meta.id + '.xml') Download SBOL File
-                        if rdfType.name == 'Component'
-                            li 
-                                a(href=meta.url + '/' + meta.id + '.gb') Download GenBank
-                        if rdfType.name == 'Component' || rdfType.name == 'Sequence'
-                            li 
-                                a(href=meta.url + '/' + meta.id + '.fasta') Downloand FASTA
-                        if rdfType.name == 'Component'
-                            li 
-                                a.sbh-download-picture Download Image
-                        if rdfType.name == 'Attachment'
-                            li 
-                                a(href=meta.url + '/download') Downloand Attachment
-           if !meta.remote && rdfType.name != 'Collection' && rdfType.name != 'Component'
-               li.dropdown.btn.btn-primary
-                    a(href=meta.url + '/uses',title='Find all uses of this '+rdfType.name,style="color:white")
-                        span.fa.fa-search
-                        |  
-           block topLevelButtons
-           if meta.triplestore != 'public'
-               li.btn.btn-success
-                    a(onclick="popup()",title='Share',style="color:white")
-                        span.fa.fa-share
-           if meta.triplestore != 'public' && locals.user && locals.user.isCurator
-               li.btn.btn-success
-                    a(href=meta.url + '/makePublic',title='Make Public',style="color:white")
-                        span.fa.fa-unlock
-           if canEdit && meta.triplestore != 'public' && (rdfType.name != 'Collection')
-               li.btn.btn-success
-                    a(href=meta.url + '/remove',title='Remove',style="color:white")
-                        span.fa.fa-remove
-           if canEdit
-               li.btn.btn-info
-                    a(href=meta.url + "/addOwner",title='Add Owner',style="color:white")
-                        span.fa.fa-id-card
-           br
-           br
+            div.btn-group
+                if (rdfType.name != 'Collection' || memberCount <= 10000)
+                        li.dropdown.btn.btn-primary
+                            span.fa.fa-download
+                                |  
+                                span.caret
+                            ul.dropdown-menu.dropdown-toggle
+                                li
+                                    a(href=meta.url + '/' + meta.id + '.xml') Download SBOL File
+                                if rdfType.name == 'Component'
+                                    li 
+                                        a(href=meta.url + '/' + meta.id + '.gb') Download GenBank
+                                if rdfType.name == 'Component' || rdfType.name == 'Sequence'
+                                    li 
+                                        a(href=meta.url + '/' + meta.id + '.fasta') Downloand FASTA
+                                if rdfType.name == 'Component'
+                                    li 
+                                        a.sbh-download-picture Download Image
+                                if rdfType.name == 'Attachment'
+                                    li 
+                                        a(href=meta.url + '/download') Downloand Attachment
+                if !meta.remote && rdfType.name != 'Collection' && rdfType.name != 'Component'
+                    li.dropdown.btn.btn-primary
+                            a(href=meta.url + '/uses',title='Find all uses of this '+rdfType.name,style="color:white")
+                                span.fa.fa-search
+                                |  
+                block topLevelButtons
+                if meta.triplestore != 'public'
+                    li.btn.btn-success
+                            a(onclick="popup()",title='Share',style="color:white")
+                                span.fa.fa-share
+                if meta.triplestore != 'public' && locals.user && locals.user.isCurator
+                    li.btn.btn-success
+                            a(href=meta.url + '/makePublic',title='Make Public',style="color:white")
+                                span.fa.fa-unlock
+                if canEdit && meta.triplestore != 'public' && (rdfType.name != 'Collection')
+                    li.btn.btn-success
+                            a(href=meta.url + '/remove',title='Remove',style="color:white")
+                                span.fa.fa-remove
+                if canEdit
+                    li.btn.btn-info
+                            a(href=meta.url + "/addOwner",title='Add Owner',style="color:white")
+                                span.fa.fa-id-card
+            br
+            br
 
         block topLevelPreview
 

--- a/templates/mixins/attachments.jade
+++ b/templates/mixins/attachments.jade
@@ -1,7 +1,6 @@
 
 mixin attachments(url, attachments, canEdit)
     if typeof(attachments) !== 'undefined' && (canEdit || attachments.length > 0)
-        h3 Attachments
         table.attachments-table.table.table-striped
             thead
                 th Type

--- a/templates/views/attachment.jade
+++ b/templates/views/attachment.jade
@@ -4,8 +4,3 @@ extends ../layouts/topLevel.jade
 block topLevelPreview
     if attachmentType === 'http://wiki.synbiohub.org/wiki/Terms/synbiohub#imageAttachment'
         img(src=attachmentDownloadURL,style='max-width: 1000px;')
-    else
-        a(href=attachmentDownloadURL)
-            button.btn.btn-primary
-                span.fa.fa-download
-                |  Download attachment

--- a/templates/views/collection.jade
+++ b/templates/views/collection.jade
@@ -33,7 +33,7 @@ block modal
                     button.btn.btn-danger(data-dismiss="modal") Close
                     button.btn.btn-primary(type="submit", form="iconForm") Save changes
 
-block topLevelBelowPropertyTable
+block topLevelPreview
     h3 Members
     table.table.table-striped.entry-detail-table.sbh-collection-members-datatable
         thead
@@ -56,14 +56,11 @@ block topLevelBelowPropertyTable
 
 block topLevelButtons
     if locals.user && (locals.user.isCurator || locals.user.isAdmin) && meta.triplestore === 'public'
-        a.btn.btn-success(data-toggle="modal", data-target="#iconModal")
-            span.fa.fa-file-image-o
-            |  Change Collection Icon
-        br
-        br
+        li.btn.btn-success
+            a(data-toggle="modal", data-target="#iconModal", title='Change Collection Icon',style="color:white")
+                span.fa.fa-file-image-o
     if meta.remote
-        a.btn.btn-success(href=copyFromRemote)
-            span.fa.fa-share-alt
-            |  Copy to SynBioHub
-        br
-        br
+        li.btn.btn-success
+            a(href=copyFromRemote, title='Copy to SynBioHub',style="color:white")
+               span.fa.fa-share-alt
+

--- a/templates/views/componentDefinition.jade
+++ b/templates/views/componentDefinition.jade
@@ -61,46 +61,48 @@ block topLevelBelowTitle
                 a(href=protein.url) #{protein.name}
 
 block topLevelButtons
-    if meta.igemDominant.description == 'true' && !meta.remote
-        a.btn.btn-success(href=meta.url + '/twins',title='This is a dominant twin')
-            span.fa.fa-search
-            | 
-            span Find Twins
-        br
-        br
-    else if !meta.remote
-        a.btn.btn-primary(href=meta.url + '/twins',title='This is NOT a dominant twin')
-            span.fa.fa-search
-            | 
-            span Find Twins
-        br
-        br
-    a.btn.btn-success(href=meta.url + '/createImplementation')
-        span.fa.fa-cubes
-        |  Create Implementation
-    br
-    br
+    li.dropdown.btn.btn-primary
+        span.fa.fa-search
+            |  
+            span.caret
+        ul.dropdown-menu.dropdown-toggle
+            li
+                a(href=href=meta.url + '/uses',title='Find all uses of this '+rdfType.name) Find Uses
+            li
+                if meta.igemDominant.description == 'true' && !meta.remote
+                    a.btn.btn-success(href=meta.url + '/twins',title='This is a dominant twin') Find Twins
+                else if !meta.remote
+                    a(href=meta.url + '/twins',title='This is NOT a dominant twin') Twins
+    li.dropdown.btn.btn-success
+        a(href=meta.url + '/createImplementation',title='Create Implementation',style="color:white")
+            span.fa.fa-cubes
     if meta.remote
-        a.btn.btn-success(href=meta.url + '/copyFromRemote')
-            span.fa.fa-share-alt
-            |  Copy to SynBioHub
-        br
-        br
-    if BenchlingRemotes
-        a.btn.btn-success(href=meta.url + '/createBenchlingSequence')
+        li.dropdown.btn.btn-primary
+            a.btn.btn-success(href=meta.url + '/copyFromRemote')
+                span.fa.fa-share-alt
+                |  Copy to SynBioHub
+    if BenchlingRemotes && ICERemotes
+        li.dropdown.btn.btn-success
             span.fa.fa-send
-            |  Send to Benchling
-        br
-        br
-    if ICERemotes
-        a.btn.btn-success(href=meta.url + '/createICEPart')
-            span.fa.fa-send
-            |  Send to ICE
-        br
-        br
+                |  
+                span.caret
+            ul.dropdown-menu.dropdown-toggle
+                li
+                    a(href=meta.url + '/createBenchlingSequence') Send to Benchling
+                li
+                    a(href=meta.url + '/createICEPart') Send to ICE
+    else if BenchlingRemotes
+        li.dropdown.btn.btn-success
+            a(href=meta.url + '/createBenchlingSequence',style="color:white")
+                span.fa.fa-send
+                |  Send to Benchling
+    else if ICERemotes
+        li.dropdown.btn.btn-success
+            a(href=meta.url + '/createICEPart',style="color:white")
+                span.fa.fa-send
+                |  Send to ICE
     if config.experimental.dataIntegration
-        a.btn.btn-primary(href=meta.url + '/integrate',title='Integrate data from an integration pipeline')
-            span.fa.fa-plus-circle
-            | Data Integration
-        br
-        br
+        li.dropdown.btn.btn-primary
+            a(href=meta.url + '/integrate',title='Integrate data from an integration pipeline',style="color:white")
+                span.fa.fa-plus-circle
+                | Data Integration

--- a/templates/views/model.jade
+++ b/templates/views/model.jade
@@ -8,7 +8,8 @@ block topLevelPropertyTable
             a(href=meta.language.uri.toString(),title=meta.language.name) #{meta.language.name}
             br
         td
-            a(href='/search/language=<'+encodeURIComponent(meta.language.uri)+'>&',title=meta.language.name) #{'Search'}
+            a(href='/search/language=<'+encodeURIComponent(meta.language.uri)+'>&',title='Find all records with this language')
+                span.fa.fa-search
             br
     tr  
         td Framework
@@ -16,7 +17,8 @@ block topLevelPropertyTable
             a(href=meta.framework.uri.toString(),title=meta.framework.name) #{meta.framework.name}
             br
         td
-            a(href='/search/framework=<'+encodeURIComponent(meta.framework.uri)+'>&',title=meta.framework.name) #{'Search'}
+            a(href='/search/framework=<'+encodeURIComponent(meta.framework.uri)+'>&',title='Find all records with this framework')
+                span.fa.fa-search
             br
     tr
         td Model File

--- a/templates/views/sequence.jade
+++ b/templates/views/sequence.jade
@@ -3,10 +3,10 @@ extends ../layouts/topLevel.jade
 
 include ../mixins/blast-button.jade
 
-block topLevelPreview
+block topLevelBelowPropertyTable
     if meta.elements
         div.row
-            div.col-md-8
+            div.col-md-12
                 div.pull-right
                     +blast-button(meta)
                 h4 Sequence (#{meta.length} #{meta.lengthUnits})


### PR DESCRIPTION
1) Buttons are shrunk to be just icons with tooltip text to provide more information.  When there are multiple items with the same icon, it is converted into a menu (such as for Download on the Component page).  This allows the buttons to be put onto a row instead of a column eliminating the problems with text running into buttons.  This also allows the Collection icon to be moved to the right of the page avoiding collection names crashing into icons.

2) Organized the sections of the page into collapsable panels.  This prevents the more detailed sections from cluttering the page especially for those who are not so interested in all the various annotations.  By default the “Details” panel is open initially.