### PR TITLE
Fix installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To access a sample instance of SynBioHub containing enriched _Bacillus subtilis_
 
 ## Installation
 
-The recommended way to install SynBioHub is via the Docker image.  See [Installation] (http://wiki.synbiohub.org/wiki/Installation) for more information.
+The recommended way to install SynBioHub is via the Docker image.  See [Installation](http://wiki.synbiohub.org/wiki/Installation) for more information.
 
 
 ## Manual Installation


### PR DESCRIPTION
The link to the installation page of the wiki was broken by a spurious space (``[] ()`` rather than ``[]()`` ).