### PR TITLE
Remove the monolith image from autobuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ services:
 script:
     - if [ "$TRAVIS_BRANCH" == "master" ]; then
       docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-      docker build -t synbiohub/synbiohub:snapshot -f docker/Dockerfile docker;
       docker build -t synbiohub/synbiohub:snapshot-standalone -f docker/Dockerfile-standalone docker;
-      docker push synbiohub/synbiohub:snapshot;
       docker push synbiohub/synbiohub:snapshot-standalone;
       fi


### PR DESCRIPTION
The monolith image cannot currently be built correctly because there's nowhere to get Virtuoso, so we shouldn't try to autobuild it. 