### PR TITLE
Change entrypoint to enable logging

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,5 +25,5 @@ RUN ln -s /mnt/config/config.local.json ./config.local.json && \
 EXPOSE 8890 7777 1111
 
 HEALTHCHECK --start-period=60s CMD ["node", "healthcheck.js"] 
-ENTRYPOINT ["node", "synbiohub.js"]
+ENTRYPOINT ["node", "synbiohub.js", "|", "tee", "synbiohub.log"]
 


### PR DESCRIPTION
Change the docker image entrypoint to make sure the logs are generated