### PR TITLE
"Combine Archive" -> "COMBINE Archive"

### DIFF
--- a/templates/layouts/topLevel.jade
+++ b/templates/layouts/topLevel.jade
@@ -15,7 +15,7 @@ block generalTopLevelButtons
                         li
                             a(href=meta.url + '/' + meta.id + '.xml') Download SBOL File
                         li
-                            a(href=meta.url + '/' + meta.id + '.omex') Download Combine Archive
+                            a(href=meta.url + '/' + meta.id + '.omex') Download COMBINE Archive
                         if rdfType.name == 'Component'
                             li 
                                 a(href=meta.url + '/' + meta.id + '.gb') Download GenBank


### PR DESCRIPTION
COMBINE is an acronym (COmputational Modeling in BIology NEtwork), so should be capitalized.