### PR TITLE
Fix initial fetch problem

### DIFF
--- a/lib/fetch/local/fetch-sbol-object-non-recursive.js
+++ b/lib/fetch/local/fetch-sbol-object-non-recursive.js
@@ -1,23 +1,12 @@
-
 var SBOLDocument = require('sboljs')
-
 var sparql = require('../../sparql/sparql')
-
 var config = require('../../config')
-
-var resolveBatch = config.get('resolveBatch')
-
-var databasePrefix = config.get('databasePrefix')
-
 var request = require('request')
-
 var async = require('async')
-
 const fs = require('mz/fs')
-
 const tmp = require('tmp-promise')
-
 const serializeSBOL = require('../../serializeSBOL')
+
 
 function fetchSBOLObjectNonRecursive(sbol, type, uri, graphUri) {
     
@@ -99,7 +88,7 @@ function getSBOLNonRecursive(sbol, type, uri, graphUri) {
 
 function completePartialDocumentNR(prefix, graphUri, sbol, type, skip, next) {
 
-    //console.log(sbol.unresolvedURIs.length + ' unresolved URI(s)')
+    var databasePrefix = config.get('databasePrefix')
 
     if(sbol.unresolvedURIs.length === 0) {
 
@@ -107,6 +96,7 @@ function completePartialDocumentNR(prefix, graphUri, sbol, type, skip, next) {
 
     } else {
 
+        var resolveBatch = config.get('resolveBatch')
         var toResolve = sbol.unresolvedURIs.filter((uri) => !sbol._resolving[uri] && uri.startsWith(prefix) &&
 						   !skip.has(uri.toString()) && uri.toString().startsWith(databasePrefix))
                                 .map((uri) => uri.toString())


### PR DESCRIPTION
The config was fetched at startup, before it was set by setup, so databasePrefix (set in setup) was wrong.
This led to problems retrieving uploaded objects at first start.

Fixes #708