### PR TITLE
Error when SBOL file is not valid XML

### DIFF
--- a/java/src/main/java/org/synbiohub/PrepareSubmissionJob.java
+++ b/java/src/main/java/org/synbiohub/PrepareSubmissionJob.java
@@ -272,11 +272,11 @@ public class PrepareSubmissionJob extends Job {
 			if (errorLog.startsWith("File is empty")) {
 				individual = new SBOLDocument();
 				errorLog = "";
-			} else if (errorLog.startsWith("sbol-10105") && !isCombineArchive) {
+			} /* else if (errorLog.startsWith("sbol-10105") && !isCombineArchive) {
 				individual = new SBOLDocument();
 				errorLog = "";
 				continue;
-			} else if (errorLog.length() > 0) {
+			} */ else if (errorLog.length() > 0) {
 				finish(new PrepareSubmissionResult(this, false, "", log, "[" + filename + "] " + errorLog,
 						attachmentFiles, tempDirPath));
 				return;


### PR DESCRIPTION
SBH was silently skipping over invalid SBOL files.  I removed this check, so it would fail when an SBOL file was not valid XML.
