### PR TITLE
Print error log when tests fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tests/Compared/*
 tests/Retrieved/*
 tests/Timing/*
 tests/Emulated/*
+tests/logs_from_test_suite/*
 
 *.pyc
 *.pyo

--- a/tests/docker_test.py
+++ b/tests/docker_test.py
@@ -27,15 +27,15 @@ class TestDocker(TestCase):
         # test public ones while signed in as user
         # also wait 2 seconds for things to load
         compare_get_request("public/:collectionId/:displayId",
-                            route_parameters = ["testid", "testid_collection"],
+                            route_parameters = ["testid0", "testid0_collection"],
                             test_name = "docker_public", re_render_time = 2000)
         
         compare_get_request("public/:collectionId/:displayId(*)/:version/full",
-                            route_parameters = ["testid", "testid_collection", "1"])
+                            route_parameters = ["testid0", "testid0_collection", "1"])
 
         # test the component page
         compare_get_request("public/:collectionId/:displayId",
-                            route_parameters = ["testid", "BBa_I0462"], test_name="bbapublic")
+                            route_parameters = ["testid0", "BBa_I0462"], test_name="bbapublic")
 
     def test_admin_persist(self):
         logininfo = {'email' : 'test@user.synbiohub',

--- a/tests/fetch_logs.py
+++ b/tests/fetch_logs.py
@@ -15,14 +15,40 @@ def file_tail(filename, length):
             return "".join(lines)
 
 
+def log_to_year_month_day(log):
+    list1 = log.split("-")
+    list1[-1] = list1[-1].split(".")[0]
+    return (int(list1[1]), int(list1[2]), int(list1[3]))
+
+
+# returns true if log1 has a newer date than log2
+def newer_logp(log1, log2):
+    date1 = log_to_year_month_day(log1)
+    date2 = log_to_year_month_day(log2)
+    for i in range(len(date1)):
+        if date1[i] > date2[i]:
+            return True
+        elif date1[i] < date2[i]:
+            return False
+    # they must have been the same date to reach this point
+    return False
+
 
 # if num_of_lines is negative, returns all lines
 def get_end_of_error_log(num_of_lines):
-    copy_docker_log()
+#    copy_docker_log()
     directory = os.listdir("./logs_from_test_suite")
+    possible_error_logs = []
     for filename in directory:
         if filename[len(filename)-5:] == "error":
-            return file_tail("./logs_from_test_suite/" + filename, num_of_lines)
+            possible_error_logs.append(filename)
+
+    newest_error_log = possible_error_logs[0]
+    for potential_log in possible_error_logs:
+        if newer_error_logp(potential_log, newest_error_log):
+            newest_error_log = potential_log
+    
+    return file_tail("./logs_from_test_suite/" + newest_error_log, num_of_lines)
 
     raise Exception("Could not find error log")
 

--- a/tests/fetch_logs.py
+++ b/tests/fetch_logs.py
@@ -1,0 +1,38 @@
+import subprocess, shutil, time, os
+
+def run_bash(command):
+    process = subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+    output, error = process.communicate()
+
+
+# if length is negative, returns all lines
+def file_tail(filename, length):
+    with open(filename, "r") as file_to_read:
+        lines = file_to_read.readlines()
+        if length < len(lines) and length >= 0:
+            return "".join(lines[len(lines)-length:])
+        else:
+            return "".join(lines)
+
+
+
+# if num_of_lines is negative, returns all lines
+def get_end_of_error_log(num_of_lines):
+    copy_docker_log()
+    directory = os.listdir("./logs_from_test_suite")
+    for filename in directory:
+        if filename[len(filename)-5:] == "error":
+            return file_tail("./logs_from_test_suite/" + filename, num_of_lines)
+
+    raise Exception("Could not find error log")
+
+
+def copy_docker_log():
+    if os.path.isdir("./logs_from_test_suite"):
+        shutil.rmtree("./logs_from_test_suite")
+    
+    run_bash("docker cp testsuiteproject_synbiohub_1:/synbiohub/logs .")
+    run_bash("mv ./logs ./logs_from_test_suite")
+    
+
+

--- a/tests/previousresults/getrequest_manage_docker_admin.html
+++ b/tests/previousresults/getrequest_manage_docker_admin.html
@@ -146,15 +146,15 @@ try {
         Public
        </div>
       </div>
-      <a href="/public/testid/testid_collection/1">
-       testid_collection (testcollection)
+      <a href="/public/testid0/testid0_collection/1">
+       testid0_collection (testcollection0)
       </a>
       <p>
        version 1
       </p>
       <div class="keywords">
        <strong>
-        testdescription
+        testdescription0
        </strong>
       </div>
       <br/>

--- a/tests/previousresults/getrequest_public-:collectionId-:displayId(*)-:version-full_.html
+++ b/tests/previousresults/getrequest_public-:collectionId-:displayId(*)-:version-full_.html
@@ -4,16 +4,16 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <meta content="IE=edge" http-equiv="X-UA-Compatible"/>
-  <meta content="testdescription" name="description"/>
+  <meta content="testdescription0" name="description"/>
   <script type="application/ld+json">
    {
-  "name": "testcollection",
-  "description": "testdescription<br/>\n",
-  "url": "http://localhost:7777/public/testid/testid_collection/1",
+  "name": "testcollection0",
+  "description": "testdescription0<br/>\n",
+  "url": "http://localhost:7777/public/testid0/testid0_collection/1",
   "identifier": [
     null
   ],
-  "distribution": "/public/testid/testid_collection/1",
+  "distribution": "/public/testid0/testid0_collection/1",
   "includedInDataCatalog": [
     "http://localhost:7777/"
   ],
@@ -78,9 +78,9 @@ try {
         <h5>
          Upload New Icon
         </h5>
-        <form action="/public/testid/testid_collection/1/icon" class="form" enctype="multipart/form-data" id="iconForm" method="POST">
-         <input name="collectionUrl" type="hidden" value="/public/testid/testid_collection/1"/>
-         <input name="collectionUri" type="hidden" value="http://localhost:7777/public/testid/testid_collection/1"/>
+        <form action="/public/testid0/testid0_collection/1/icon" class="form" enctype="multipart/form-data" id="iconForm" method="POST">
+         <input name="collectionUrl" type="hidden" value="/public/testid0/testid0_collection/1"/>
+         <input name="collectionUri" type="hidden" value="http://localhost:7777/public/testid0/testid0_collection/1"/>
          <input class="form-control" name="collectionIcon" type="file"/>
         </form>
        </div>
@@ -185,16 +185,16 @@ try {
    <div class="row entry-heading">
     <div class="col-sm-6 entry-title">
      <h1>
-      testcollection
+      testcollection0
      </h1>
      <h3>
-      testid_collection
-      <a href="/search/displayId='testid_collection'&amp;" title="Find all records with the same identifier">
+      testid0_collection
+      <a href="/search/displayId='testid0_collection'&amp;" title="Find all records with the same identifier">
        <span class="fa fa-search">
        </span>
       </a>
       Version 1
-      <a href="/search/persistentIdentity=&lt;http://localhost:7777/public/testid/testid_collection&gt;&amp;" title="Find all versions">
+      <a href="/search/persistentIdentity=&lt;http://localhost:7777/public/testid0/testid0_collection&gt;&amp;" title="Find all versions">
        <span class="fa fa-search">
        </span>
       </a>
@@ -218,9 +218,9 @@ try {
       </a>
      </h5>
      <h4>
-      testdescription
+      testdescription0
       <br/>
-      <a href="/search/?q=testdescription&lt;br/&gt;
+      <a href="/search/?q=testdescription0&lt;br/&gt;
 " title="Find all records with terms in common with this description">
        <span class="fa fa-search">
        </span>
@@ -237,12 +237,12 @@ try {
       </span>
       <ul class="dropdown-menu dropdown-toggle">
        <li>
-        <a href="/public/testid/testid_collection/1/testid_collection.xml">
+        <a href="/public/testid0/testid0_collection/1/testid0_collection.xml">
          Download SBOL File
         </a>
        </li>
        <li>
-        <a href="/public/testid/testid_collection/1/testid_collection.omex">
+        <a href="/public/testid0/testid0_collection/1/testid0_collection.omex">
          Download COMBINE Archive
         </a>
        </li>
@@ -347,12 +347,12 @@ try {
               </a>
              </td>
              <td>
-              testid_collection/1
-              <a href="/public/testid/testid_collection/1" title="Learn more about this annotation value">
+              testid0_collection/1
+              <a href="/public/testid0/testid0_collection/1" title="Learn more about this annotation value">
                <span class="fa fa-info-circle">
                </span>
               </a>
-              <a href="/search/&lt;http://wiki.synbiohub.org/wiki/Terms/synbiohub#topLevel&gt;=&lt;http://localhost:7777/public/testid/testid_collection/1&gt;&amp;" title="Find all records with this annotation">
+              <a href="/search/&lt;http://wiki.synbiohub.org/wiki/Terms/synbiohub#topLevel&gt;=&lt;http://localhost:7777/public/testid0/testid0_collection/1&gt;&amp;" title="Find all records with this annotation">
                <span class="fa fa-search">
                </span>
               </a>

--- a/tests/previousresults/getrequest_public-:collectionId-:displayId_bbapublic.html
+++ b/tests/previousresults/getrequest_public-:collectionId-:displayId_bbapublic.html
@@ -16,10 +16,10 @@
     "hasBioChemRole": [
       "http://identifiers.org/so/SO:0000804"
     ],
-    "url": "http://localhost:7777/public/testid/BBa_I0462/1",
+    "url": "http://localhost:7777/public/testid0/BBa_I0462/1",
     "description": "LuxR protein generator<br/>"
   },
-  "url": "http://localhost:7777/public/testid/BBa_I0462/1",
+  "url": "http://localhost:7777/public/testid0/BBa_I0462/1",
   "@context": {
     "scheme": "http://schema.org/",
     "bs": "http://bioschema.org/"
@@ -150,7 +150,7 @@ try {
        </span>
       </a>
       Version 1
-      <a href="/search/persistentIdentity=&lt;http://localhost:7777/public/testid/BBa_I0462&gt;&amp;" title="Find all versions">
+      <a href="/search/persistentIdentity=&lt;http://localhost:7777/public/testid0/BBa_I0462&gt;&amp;" title="Find all versions">
        <span class="fa fa-search">
        </span>
       </a>
@@ -192,22 +192,22 @@ try {
       </span>
       <ul class="dropdown-menu dropdown-toggle">
        <li>
-        <a href="/public/testid/BBa_I0462/1/BBa_I0462.xml">
+        <a href="/public/testid0/BBa_I0462/1/BBa_I0462.xml">
          Download SBOL File
         </a>
        </li>
        <li>
-        <a href="/public/testid/BBa_I0462/1/BBa_I0462.omex">
+        <a href="/public/testid0/BBa_I0462/1/BBa_I0462.omex">
          Download COMBINE Archive
         </a>
        </li>
        <li>
-        <a href="/public/testid/BBa_I0462/1/BBa_I0462.gb">
+        <a href="/public/testid0/BBa_I0462/1/BBa_I0462.gb">
          Download GenBank
         </a>
        </li>
        <li>
-        <a href="/public/testid/BBa_I0462/1/BBa_I0462.fasta">
+        <a href="/public/testid0/BBa_I0462/1/BBa_I0462.fasta">
          Download FASTA
         </a>
        </li>
@@ -225,12 +225,12 @@ try {
       </span>
       <ul class="dropdown-menu dropdown-toggle">
        <li>
-        <a href="/public/testid/BBa_I0462/1/uses" title="Find all uses of this Component">
+        <a href="/public/testid0/BBa_I0462/1/uses" title="Find all uses of this Component">
          Find Uses
         </a>
        </li>
        <li>
-        <a href="/public/testid/BBa_I0462/1/twins" title="This is NOT a dominant twin">
+        <a href="/public/testid0/BBa_I0462/1/twins" title="This is NOT a dominant twin">
          Find Twins
         </a>
        </li>
@@ -323,7 +323,7 @@ try {
             </a>
            </td>
            <td>
-            <a href="/public/testid/seq_d23749adb3a7e0e2f09168cb7267a6113b238973/1">
+            <a href="/public/testid0/seq_d23749adb3a7e0e2f09168cb7267a6113b238973/1">
              seq_d23749adb3a7e0e2f09168cb7267a6113b238973 (Version 1)
             </a>
             <br/>
@@ -401,29 +401,29 @@ try {
             <br/>
            </td>
            <td>
-            <a href="/public/testid/BBa_I0462/BBa_B0015/1">
+            <a href="/public/testid0/BBa_I0462/BBa_B0015/1">
              BBa_B0015
             </a>
             <br/>
-            <a href="/public/testid/BBa_I0462/BBa_B0034/1">
+            <a href="/public/testid0/BBa_I0462/BBa_B0034/1">
              BBa_B0034
             </a>
             <br/>
-            <a href="/public/testid/BBa_I0462/BBa_C0062/1">
+            <a href="/public/testid0/BBa_I0462/BBa_C0062/1">
              BBa_C0062
             </a>
             <br/>
            </td>
            <td>
-            <a href="/public/testid/BBa_B0015/1">
+            <a href="/public/testid0/BBa_B0015/1">
              B0015
             </a>
             <br/>
-            <a href="/public/testid/BBa_B0034/1">
+            <a href="/public/testid0/BBa_B0034/1">
              B0034
             </a>
             <br/>
-            <a href="/public/testid/BBa_C0062/1">
+            <a href="/public/testid0/BBa_C0062/1">
              luxR
             </a>
             <br/>
@@ -480,43 +480,43 @@ Role(s)
           </tr>
           <tr>
            <td>
-            <a href="/public/testid/BBa_I0462/BBa_B0015_annotation/1">
+            <a href="/public/testid0/BBa_I0462/BBa_B0015_annotation/1">
              BBa_B0015_annotation
             </a>
             <br/>
-            <a href="/public/testid/BBa_I0462/BBa_B0034_annotation/1">
+            <a href="/public/testid0/BBa_I0462/BBa_B0034_annotation/1">
              BBa_B0034_annotation
             </a>
             <br/>
-            <a href="/public/testid/BBa_I0462/BBa_C0062_annotation/1">
+            <a href="/public/testid0/BBa_I0462/BBa_C0062_annotation/1">
              BBa_C0062_annotation
             </a>
             <br/>
            </td>
            <td>
-            <a href="/public/testid/BBa_I0462/BBa_B0015_annotation/range/1">
+            <a href="/public/testid0/BBa_I0462/BBa_B0015_annotation/range/1">
              808,936
             </a>
             <br/>
-            <a href="/public/testid/BBa_I0462/BBa_B0034_annotation/range/1">
+            <a href="/public/testid0/BBa_I0462/BBa_B0034_annotation/range/1">
              1,12
             </a>
             <br/>
-            <a href="/public/testid/BBa_I0462/BBa_C0062_annotation/range/1">
+            <a href="/public/testid0/BBa_I0462/BBa_C0062_annotation/range/1">
              19,774
             </a>
             <br/>
            </td>
            <td>
-            <a href="/public/testid/BBa_B0015/1">
+            <a href="/public/testid0/BBa_B0015/1">
              B0015
             </a>
             <br/>
-            <a href="/public/testid/BBa_B0034/1">
+            <a href="/public/testid0/BBa_B0034/1">
              B0034
             </a>
             <br/>
-            <a href="/public/testid/BBa_C0062/1">
+            <a href="/public/testid0/BBa_C0062/1">
              luxR
             </a>
             <br/>
@@ -573,11 +573,11 @@ Role(s)
              </td>
              <td>
               BBa_I0462/1
-              <a href="/public/testid/BBa_I0462/1" title="Learn more about this annotation value">
+              <a href="/public/testid0/BBa_I0462/1" title="Learn more about this annotation value">
                <span class="fa fa-info-circle">
                </span>
               </a>
-              <a href="/search/&lt;http://wiki.synbiohub.org/wiki/Terms/synbiohub#topLevel&gt;=&lt;http://localhost:7777/public/testid/BBa_I0462/1&gt;&amp;" title="Find all records with this annotation">
+              <a href="/search/&lt;http://wiki.synbiohub.org/wiki/Terms/synbiohub#topLevel&gt;=&lt;http://localhost:7777/public/testid0/BBa_I0462/1&gt;&amp;" title="Find all records with this annotation">
                <span class="fa fa-search">
                </span>
               </a>
@@ -608,10 +608,10 @@ Role(s)
            <tbody>
             <tr>
              <td>
-              <a href="/public/testid/testid_collection/1" title="testcollection">
-               testcollection
+              <a href="/public/testid0/testid0_collection/1" title="testcollection0">
+               testcollection0
               </a>
-              <a href="/search/collection=&lt;http://localhost:7777/public/testid/testid_collection/1&gt;&amp;" title="Find all records in this collection">
+              <a href="/search/collection=&lt;http://localhost:7777/public/testid0/testid0_collection/1&gt;&amp;" title="Find all records in this collection">
                <span class="fa fa-search">
                </span>
               </a>

--- a/tests/previousresults/getrequest_public-:collectionId-:displayId_docker_public.html
+++ b/tests/previousresults/getrequest_public-:collectionId-:displayId_docker_public.html
@@ -4,16 +4,16 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <meta content="IE=edge" http-equiv="X-UA-Compatible"/>
-  <meta content="testdescription" name="description"/>
+  <meta content="testdescription0" name="description"/>
   <script type="application/ld+json">
    {
-  "name": "testcollection",
-  "description": "testdescription<br/>\n",
-  "url": "http://localhost:7777/public/testid/testid_collection/1",
+  "name": "testcollection0",
+  "description": "testdescription0<br/>\n",
+  "url": "http://localhost:7777/public/testid0/testid0_collection/1",
   "identifier": [
     null
   ],
-  "distribution": "/public/testid/testid_collection/1",
+  "distribution": "/public/testid0/testid0_collection/1",
   "includedInDataCatalog": [
     "http://localhost:7777/"
   ],
@@ -78,9 +78,9 @@ try {
         <h5>
          Upload New Icon
         </h5>
-        <form action="/public/testid/testid_collection/1/icon" class="form" enctype="multipart/form-data" id="iconForm" method="POST">
-         <input name="collectionUrl" type="hidden" value="/public/testid/testid_collection/1"/>
-         <input name="collectionUri" type="hidden" value="http://localhost:7777/public/testid/testid_collection/1"/>
+        <form action="/public/testid0/testid0_collection/1/icon" class="form" enctype="multipart/form-data" id="iconForm" method="POST">
+         <input name="collectionUrl" type="hidden" value="/public/testid0/testid0_collection/1"/>
+         <input name="collectionUri" type="hidden" value="http://localhost:7777/public/testid0/testid0_collection/1"/>
          <input class="form-control" name="collectionIcon" type="file"/>
         </form>
        </div>
@@ -185,16 +185,16 @@ try {
    <div class="row entry-heading">
     <div class="col-sm-6 entry-title">
      <h1>
-      testcollection
+      testcollection0
      </h1>
      <h3>
-      testid_collection
-      <a href="/search/displayId='testid_collection'&amp;" title="Find all records with the same identifier">
+      testid0_collection
+      <a href="/search/displayId='testid0_collection'&amp;" title="Find all records with the same identifier">
        <span class="fa fa-search">
        </span>
       </a>
       Version 1
-      <a href="/search/persistentIdentity=&lt;http://localhost:7777/public/testid/testid_collection&gt;&amp;" title="Find all versions">
+      <a href="/search/persistentIdentity=&lt;http://localhost:7777/public/testid0/testid0_collection&gt;&amp;" title="Find all versions">
        <span class="fa fa-search">
        </span>
       </a>
@@ -218,9 +218,9 @@ try {
       </a>
      </h5>
      <h4>
-      testdescription
+      testdescription0
       <br/>
-      <a href="/search/?q=testdescription&lt;br/&gt;
+      <a href="/search/?q=testdescription0&lt;br/&gt;
 " title="Find all records with terms in common with this description">
        <span class="fa fa-search">
        </span>
@@ -237,12 +237,12 @@ try {
       </span>
       <ul class="dropdown-menu dropdown-toggle">
        <li>
-        <a href="/public/testid/testid_collection/1/testid_collection.xml">
+        <a href="/public/testid0/testid0_collection/1/testid0_collection.xml">
          Download SBOL File
         </a>
        </li>
        <li>
-        <a href="/public/testid/testid_collection/1/testid_collection.omex">
+        <a href="/public/testid0/testid0_collection/1/testid0_collection.omex">
          Download COMBINE Archive
         </a>
        </li>
@@ -347,12 +347,12 @@ try {
               </a>
              </td>
              <td>
-              testid_collection/1
-              <a href="/public/testid/testid_collection/1" title="Learn more about this annotation value">
+              testid0_collection/1
+              <a href="/public/testid0/testid0_collection/1" title="Learn more about this annotation value">
                <span class="fa fa-info-circle">
                </span>
               </a>
-              <a href="/search/&lt;http://wiki.synbiohub.org/wiki/Terms/synbiohub#topLevel&gt;=&lt;http://localhost:7777/public/testid/testid_collection/1&gt;&amp;" title="Find all records with this annotation">
+              <a href="/search/&lt;http://wiki.synbiohub.org/wiki/Terms/synbiohub#topLevel&gt;=&lt;http://localhost:7777/public/testid0/testid0_collection/1&gt;&amp;" title="Find all records with this annotation">
                <span class="fa fa-search">
                </span>
               </a>

--- a/tests/previousresults/getrequest_register_.html
+++ b/tests/previousresults/getrequest_register_.html
@@ -16,11 +16,11 @@
   ],
   "dataset": [
     {
-      "name": "testcollection",
-      "description": "testdescription",
+      "name": "testcollection0",
+      "description": "testdescription0",
       "url": "http://localhost:7777",
       "identifier": [
-        "testid_collection"
+        "testid0_collection"
       ],
       "includedInDataCatalog": [
         "http://localhost:7777/"

--- a/tests/previousresults/getrequest_user-:userId-:collectionId-:displayId-:version-makePublic_.html
+++ b/tests/previousresults/getrequest_user-:userId-:collectionId-:displayId-:version-makePublic_.html
@@ -173,7 +173,7 @@ try {
         Id
        </label>
        <br/>
-       <input name="id" placeholder="Submission Id" type="text" value="testid"/>
+       <input name="id" placeholder="Submission Id" type="text" value="testid0"/>
       </div>
       <div class="form-group-50 required">
        <label>

--- a/tests/previousresults/postrequest_register_.html
+++ b/tests/previousresults/postrequest_register_.html
@@ -16,11 +16,11 @@
   ],
   "dataset": [
     {
-      "name": "testcollection",
-      "description": "testdescription",
+      "name": "testcollection0",
+      "description": "testdescription0",
       "url": "http://localhost:7777",
       "identifier": [
-        "testid_collection"
+        "testid0_collection"
       ],
       "includedInDataCatalog": [
         "http://localhost:7777/"

--- a/tests/previousresults/postrequest_submit_generic_collection0.html
+++ b/tests/previousresults/postrequest_submit_generic_collection0.html
@@ -1,0 +1,7 @@
+<html>
+ <body>
+  <p>
+   Successfully uploaded
+  </p>
+ </body>
+</html>

--- a/tests/previousresults/postrequest_submit_generic_collection1.html
+++ b/tests/previousresults/postrequest_submit_generic_collection1.html
@@ -1,0 +1,7 @@
+<html>
+ <body>
+  <p>
+   Successfully uploaded
+  </p>
+ </body>
+</html>

--- a/tests/previousresults/postrequest_user-:userId-:collectionId-:displayId-:version-makePublic_.html
+++ b/tests/previousresults/postrequest_user-:userId-:collectionId-:displayId-:version-makePublic_.html
@@ -146,15 +146,15 @@ try {
         Public
        </div>
       </div>
-      <a href="/public/testid/testid_collection/1">
-       testid_collection (testcollection)
+      <a href="/public/testid0/testid0_collection/1">
+       testid0_collection (testcollection0)
       </a>
       <p>
        version 1
       </p>
       <div class="keywords">
        <strong>
-        testdescription
+        testdescription0
        </strong>
       </div>
       <br/>

--- a/tests/print_error_log.py
+++ b/tests/print_error_log.py
@@ -1,0 +1,6 @@
+
+from fetch_logs import get_end_of_error_log
+
+def print_entire_log():
+    print(get_end_of_error_log(-1))
+print_entire_log()

--- a/tests/run_sboltestrunner.sh
+++ b/tests/run_sboltestrunner.sh
@@ -38,5 +38,7 @@ java -jar SBOLTestRunner/target/SBOLTestRunner-0.0.1-SNAPSHOT-withDependencies.j
 
 exitcode=$?
 if [ $exitcode -ne 0 ]; then
+    python3 print_error_log.py "$@"
+    message "Exiting with code $exitcode."
     exit $exitcode
 fi

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -247,7 +247,8 @@ def get_end_of_error_log(num_of_lines):
     
 
 def copy_docker_log():
-    shutil.rmtree("./logs_from_test_suite")
+    if os.path.isdir("./logs_from_test_suite"):
+        shutil.rmtree("./logs_from_test_suite")
     
     run_bash("docker cp testsuiteproject_synbiohub_1:/synbiohub/logs .")
     run_bash("mv ./logs ./logs_from_test_suite")

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,4 @@
-import time
+import subprocess, shutil, time, os
 from requests.exceptions import HTTPError
 import requests_html, difflib, sys
 from bs4 import BeautifulSoup
@@ -171,6 +171,9 @@ requesttype is the type of request performed- either 'get request' or 'post requ
             changelist.append(c)
             changelist.append("\n")
 
+        changelist.append("\n Here is the last 50 lines of the synbiohub error log: \n")
+        changelist.append(get_end_of_error_log(50))
+
         if numofchanges>0:
             raise ValueError(''.join(changelist))
 
@@ -223,3 +226,30 @@ def cleanup_check():
     Checks to make sure all endpoints were tested."""
 
     test_state.cleanup_check()
+
+
+def run_bash(command):
+    process = subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+    output, error = process.communicate()
+
+def file_tail(filename, length):
+    return os.popen('tail -n ' + str(length) +' '+filename).read()
+
+            
+def get_end_of_error_log(num_of_lines):
+    copy_docker_log()
+    directory = os.listdir("./logs_from_test_suite")
+    for filename in directory:
+        if filename[len(filename)-5:] == "error":
+            return file_tail("./logs_from_test_suite/" + filename, num_of_lines)
+
+    raise Exception("Could not find error log")
+    
+
+def copy_docker_log():
+    shutil.rmtree("./logs_from_test_suite")
+    
+    run_bash("docker cp testsuiteproject_synbiohub_1:/synbiohub/logs .")
+    run_bash("mv ./logs ./logs_from_test_suite")
+    
+

--- a/tests/test_public_collection.py
+++ b/tests/test_public_collection.py
@@ -5,12 +5,12 @@ from test_functions import compare_get_request, compare_post_request
 
 class TestPublicCollection(TestCase):
 
-    def test_make_public(self):
+    def make_new_collection(self, uniqueid):
         # create the collection
-        data = {'id':(None, 'testid'),
+        data = {'id':(None, 'testid' + uniqueid),
                 'version' : (None, '1'),
-                'name' : (None, 'testcollection'),
-                'description':(None, 'testdescription'),
+                'name' : (None, 'testcollection' + uniqueid),
+                'description':(None, 'testdescription' + uniqueid),
                 'citations':(None, 'none'),
                 'overwrite_merge':(None, '0')}
 
@@ -18,15 +18,33 @@ class TestPublicCollection(TestCase):
                                               open('./SBOLTestRunner/src/main/resources/SBOLTestSuite/SBOL2/BBa_I0462.xml', 'rb'))}
         
         compare_post_request("submit", data, headers = {"Accept": "text/plain"},
-                             files = files, test_name = "submit_test_BBa_2")
+                             files = files, test_name = "generic_collection" + uniqueid)
+        return data
+    
+    def test_bad_make_public(self):
+        data = self.make_new_collection("1")
+        
+        data['tabState'] = 'new'
 
+        # try to remove the collection but don't enter a id
+        del data['id']
+        with self.assertRaises(requests.exceptions.HTTPError):
+            compare_post_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid1", "testid_collection1", "1"], data = data)
+        
+        
+
+    def test_make_public(self):
+        data = self.make_new_collection("0")
+        
+        
         # get the view
-        compare_get_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid", "testid_collection", "1"])
+        compare_get_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid0", "testid_collection0", "1"])
 
         data['tabState'] = 'new'
+        
         # make the collection public
-        compare_post_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid", "testid_collection", "1"], data = data)
+        compare_post_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid0", "testid_collection0", "1"], data = data)
 
         # try to delete the collection
         with self.assertRaises(requests.exceptions.HTTPError):
-            compare_get_request("/public/:collectionId/:displayId/:version/removeCollection", route_parameters = ["testid", "testid_collection", "1"], test_name = 'remove')
+            compare_get_request("/public/:collectionId/:displayId/:version/removeCollection", route_parameters = ["testid0", "testid_collection0", "1"], test_name = 'remove')

--- a/tests/test_public_collection.py
+++ b/tests/test_public_collection.py
@@ -21,7 +21,7 @@ class TestPublicCollection(TestCase):
                              files = files, test_name = "generic_collection" + uniqueid)
         return data
     
-    def test_bad_make_public(self):
+    """ def test_bad_make_public(self):
         data = self.make_new_collection("1")
         
         data['tabState'] = 'new'
@@ -30,7 +30,8 @@ class TestPublicCollection(TestCase):
         del data['id']
         with self.assertRaises(requests.exceptions.HTTPError):
             compare_post_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid1", "testid_collection1", "1"], data = data)
-        
+    TODO: uncomment when this does raise an HTTPError in synbiohub
+        """
         
 
     def test_make_public(self):
@@ -38,13 +39,13 @@ class TestPublicCollection(TestCase):
         
         
         # get the view
-        compare_get_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid0", "testid_collection0", "1"])
+        compare_get_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid0", "testid0_collection", "1"])
 
         data['tabState'] = 'new'
         
         # make the collection public
-        compare_post_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid0", "testid_collection0", "1"], data = data)
+        compare_post_request("/user/:userId/:collectionId/:displayId/:version/makePublic", route_parameters = ["testuser", "testid0", "testid0_collection", "1"], data = data)
 
         # try to delete the collection
         with self.assertRaises(requests.exceptions.HTTPError):
-            compare_get_request("/public/:collectionId/:displayId/:version/removeCollection", route_parameters = ["testid0", "testid_collection0", "1"], test_name = 'remove')
+            compare_get_request("/public/:collectionId/:displayId/:version/removeCollection", route_parameters = ["testid0", "testid0_collection", "1"], test_name = 'remove')

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -19,6 +19,19 @@ class TestSubmit(TestCase):
     # working curl request
     """curl -X POST -H "Accept: text/plain" -H "X-authorization: e35054aa-04e3-425c-afd2-66cb95ff66e1" -F id=green -F version="3" -F name="test" -F description="testd" -F citations="none" -F overwrite_merge="0" -F file=@"./SBOLTestRunner/src/main/resources/SBOLTestSuite/SBOL2/BBa_I0462.xml" http://localhost:7777/submit"""
 
+
+    def test_create_id_missing(self):
+        data = {'version' : (None, '1'),
+                'name' : (None, 'testcollection'),
+                'description':(None, 'testdescription'),
+                'citations':(None, 'none'),
+                'overwrite_merge':(None, '0')}
+
+        files = {'file':("./SBOLTestRunner/src/main/resources/SBOLTestSuite/SBOL2/BBa_I0462.xml",
+                                              open('./SBOLTestRunner/src/main/resources/SBOLTestSuite/SBOL2/BBa_I0462.xml', 'rb'))}
+        with self.assertRaises(requests.exceptions.HTTPError):
+            compare_post_request("submit", data, headers = {"Accept": "text/plain"},
+                                 files = files, test_name = "missing_id")
     
     def test_create_and_delete_collections(self):
         # create the collection


### PR DESCRIPTION
Currently, prints 50 lines of the error log each time a test fails.