### PR TITLE
Send instance URL to plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,3 +1,5 @@
+const config = require('./config')
+const extend = require('xtend')
 const request = require('request')
 const util = require('util')
 const stream = require('./api/stream')
@@ -9,6 +11,13 @@ const get = util.promisify(request.get)
 function callPlugin (plugin, requestData) {
   let runUrl = plugin.url + 'run'
   let statusUrl = plugin.url + 'status'
+
+  let instanceData = {
+    instanceUrl: config.get('instanceUrl')
+  }
+
+  requestData = extend(requestData, instanceData)
+  console.debug(`Sending ${JSON.stringify(requestData)} to ${runUrl}`)
 
   let postParams = {
     json: true,


### PR DESCRIPTION
Adds the `instanceUrl` parameter to plugin request.

Closes #900 