### PR TITLE
Fix duplicate modified issue

### DIFF
--- a/sparql/UpdateTriple.sparql
+++ b/sparql/UpdateTriple.sparql
@@ -12,4 +12,7 @@ INSERT {
 
 WHERE {
     <$subject> <$predicate> ?o .
+    OPTIONAL {
+        <$subject> dcterms:modified ?mod
+    }
 }


### PR DESCRIPTION
This changes the dcterms:modified update so that it replaces the previous value instead of adding additional triples. 