### PR TITLE
Update libSBOLj to 2.4.1-SNAPSHOT

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
           <groupId>org.sbolstandard</groupId>
           <artifactId>libSBOLj</artifactId>
-          <version>2.4.0</version>
+          <version>2.4.1-SNAPSHOT</version>
       </dependency>
       <dependency>
           <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This update of the library includes a more robust GenBank converter
