### PR TITLE
Don't crash on missing file

### DIFF
--- a/lib/api/download.js
+++ b/lib/api/download.js
@@ -1,17 +1,10 @@
-var pug = require('pug')
-
 const { fetchSBOLObjectRecursive } = require('../fetch/fetch-sbol-object-recursive')
-
-var serializeSBOL = require('../serializeSBOL')
-
 var config = require('../config')
-
 var getUrisFromReq = require('../getUrisFromReq')
-
 const uploads = require('../uploads')
 
 module.exports = function (req, res) {
-  const { graphUri, uri, designId, share } = getUrisFromReq(req, res)
+  const { graphUri, uri } = getUrisFromReq(req, res)
 
   fetchSBOLObjectRecursive(uri, graphUri).then((result) => {
     const sbol = result.sbol
@@ -28,7 +21,6 @@ module.exports = function (req, res) {
     })
 
     const readStream = uploads.createCompressedReadStream(attachmentHash)
-
     const mimeType = config.get('attachmentTypeToMimeType')[attachmentType] || 'application/octet-stream'
 
     res.status(200)

--- a/lib/uploads.js
+++ b/lib/uploads.js
@@ -75,7 +75,7 @@ function createUpload (inputStream) {
         } else {
           console.log('Upload does not already exist')
 
-          const { hashPrefix, dir, filename } = getPaths(hash)
+          const { dir, filename } = getPaths(hash)
 
           console.log('Moving file to ' + filename)
 
@@ -125,17 +125,17 @@ function createUpload (inputStream) {
 }
 
 function createUncompressedReadStream (hash) {
-  const gunzip = zlib.createGunzip()
+  let gunzip = zlib.createGunzip()
 
-  const { filename } = getPaths(hash)
-
-  return fs.createReadStream(filename).pipe(gunzip)
+  return createCompressedReadStream(hash).pipe(gunzip)
 }
 
 function createCompressedReadStream (hash) {
-  const gunzip = zlib.createGunzip()
-
   const { filename } = getPaths(hash)
+
+  if (!fs.existsSync(filename)) {
+    throw new Error('File does not exist.')
+  }
 
   return fs.createReadStream(filename)
 }


### PR DESCRIPTION
Instead of letting an error event get to the top level and kill node, check if the file exists and throw an exception to be caught when an attachment is missing.

Closes #954 