### PR TITLE
Use local fetch for public graph

### DIFF
--- a/lib/fetch/local/fetch-sbol-object-recursive.js
+++ b/lib/fetch/local/fetch-sbol-object-recursive.js
@@ -182,7 +182,7 @@ function getSBOLRecursive (sbol, type, graphUri) {
                 prefix = uri.toString()
               }
             }
-            if (!uri.toString().startsWith(graphUri) && webOfRegistries[prefix]) {
+            if (!uri.toString().startsWith(config.get('databasePrefix')) && webOfRegistries[prefix]) {
               uri = uri.replace(prefix, webOfRegistries[prefix]) + '/sbol'
               console.log('Fetching non-local:' + uri)
               request({
@@ -284,9 +284,9 @@ function completePartialDocument (graphUri, sbol, type, skip, next) {
 function retrieveSBOL (graphUri, sbol, type, uris, next) {
   Object.assign(sbol._resolving, uris)
 
-  var countQuery = sparqlDescribeSubjects(sbol, type, uris, true)
+  var countQuery = sparqlDescribeSubjects(sbol, type, uris, true, graphUri)
 
-  var query = sparqlDescribeSubjects(sbol, type, uris, false)
+  var query = sparqlDescribeSubjects(sbol, type, uris, false, graphUri)
 
   var offset = 0
   var limit = config.get('staggeredQueryLimit')
@@ -335,7 +335,7 @@ function retrieveSBOL (graphUri, sbol, type, uris, next) {
   })
 }
 
-function sparqlDescribeSubjects (sbol, type, uris, isCount) {
+function sparqlDescribeSubjects (sbol, type, uris, isCount, graphUri) {
 /*
 var triples = uris.map((uri, n) =>
 sparql.escapeIRI(uri) + ' ?p' + n + ' ?o' + n + ' .'
@@ -349,10 +349,12 @@ return [
 '}'
 ]).join('\n') */
 
+  var from = 'FROM <' + config.get('databasePrefix') + 'public>' + ' FROM <' + graphUri + '>'
+
   var query = [
     isCount
-      ? 'SELECT (count(?s) as ?count) WHERE {'
-      : 'CONSTRUCT { ?s ?p ?o } WHERE {'
+      ? 'SELECT (count(?s) as ?count) ' + from + ' WHERE {'
+      : 'CONSTRUCT { ?s ?p ?o } ' + from + ' WHERE {'
   ]
 
   var isFirst = true


### PR DESCRIPTION
I discovered that local public objects were being fetched as if their were non-local.  This greatly impacted fetch performance.
