### PR TITLE
Updated the README for macOS manual installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,52 @@ The recommended way to install SynBioHub is via the Docker image.  See [Installa
 
 SynBioHub has both JavaScript (node.js) and Java components.
 
-Prequisites:
+#### Prequisites:
 
-* Linux (only tested with Ubuntu 18.04.01) or macOS
-* A JDK
-* [Apache Maven](https://maven.apache.org/)
-* [node.js](https://nodejs.org/en/) >= 11.0.0
-* [OpenLink Virtuoso](https://github.com/openlink/virtuoso-opensource) 7.x.x
-* [rapper](http://librdf.org/raptor/rapper.html) (apt install `raptor2-utils`)
-* [jq](https://stedolan.github.io/jq/) (apt install `jq`)
+Linux (only tested with Ubuntu 18.04.01) or macOS
+   * If you're using macOS, first install [homebrew](https://brew.sh/)
+
+A JDK
+| OS | Command |
+| --- | --- |
+| Ubuntu | apt install `default-jdk` |
+| Mac | brew install `openjdk` |
+
+[Apache Maven](https://maven.apache.org/)
+
+| OS | Command |
+| --- | --- |
+| Ubuntu | apt install `maven` |
+| Mac | brew install `maven` |
+
+[node.js](https://nodejs.org/en/) >= 11.0.0
+
+| OS | Command/Link |
+| --- | --- |
+| Ubuntu | visit https://nodejs.org/en/ |
+| Mac | brew install `node` |
+
+[OpenLink Virtuoso](https://github.com/openlink/virtuoso-opensource) 7.x.x
+
+| OS | Command/Link |
+| --- | --- |
+| Ubuntu | visit https://github.com/openlink/virtuoso-opensource |
+| Mac | brew install `virtuoso` |
+
+[rapper](http://librdf.org/raptor/rapper.html)
+
+| OS | Command |
+| --- | --- |
+| Ubuntu | apt install `raptor2-utils` |
+| Mac | brew install `raptor` |
+
+[jq](https://stedolan.github.io/jq/)
+
+| OS | Command |
+| --- | --- |
+| Ubuntu | apt install `jq` |
+| Mac | brew install `jq` |
+
 
 ### Ubuntu 18.04.01
  1. Install Virtuoso 7 from source at
@@ -40,17 +77,29 @@ Prequisites:
     1. Download the Node setup script `curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -`
     2. Update your package repositories `apt update`
  3. Install the necessary packages `apt install default-jdk maven raptor2-utils nodejs jq build-essential python`
- 4. Clone the SynBioHub repository `git clone https://github.com/SynBioHub/synbiohub`
- 5. Change to the SynBioHub directory `cd synbiohub`
- 6. Build the Java components with Maven `cd java && mvn package`
- 7. Return to the root directory and install the Node dependencies with yarn `cd ../ && yarn install`
+ 4. Start virtuoso process `virtuoso-t +configfile /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.ini -f`
+
+### MacOS
+ 1. Install the necessary packages `brew install openjdk maven node virtuoso raptor jq python`
+ 2. Start virtuoso process 
+    1. `cd /usr/local/Cellar/virtuoso/7.2.5.1_1/var/lib/virtuoso/db`
+         * The command above is based on where the virtuoso.ini file is located. Your installation might be located
+           somewhere different than `/usr/local/Cellar/virtuoso/7.2.5.1_1/var/lib/virtuoso/db`, or the version might be
+           different (`7.2.5.1_1` might be `7.3.6.1_1` or any other version number).
+         * If you're having trouble finding the location of the virtuoso.ini file, run `sudo find / -name virtuoso.ini`.
+           Press the control and c keys simultaneously to quit the search.
+    2. `virtuoso-t -f`
+
+### Both Systems
+ 1. Clone the SynBioHub repository `git clone https://github.com/SynBioHub/synbiohub`
+ 2. Change to the SynBioHub directory `cd synbiohub`
+ 3. Build the Java components with Maven `cd java && mvn package`
+ 4. Return to the root directory and install the Node dependencies with yarn `cd ../ && yarn install`
     Make sure that yarn is being used, not 'cmdtest'.
- 8. Install nodemon and forever with `npm install nodemon -g && npm install forever -g`
- 9. Start virtuoso process `virtuoso-t +configfile /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.ini -f`
- 10. Add SPARQL update rights to the dba user in virtuoso.
+ 5. Install nodemon and forever with `npm install nodemon -g && npm install forever -g`
+ 6. Add SPARQL update rights to the dba user in virtuoso.
  * Visit localhost:8890, click conductor on the left hand side, and login with user name dba and password dba.
  * Visit system admin -> user accounts in the menu at the top.
  * Find the accound labled dba and edit.<br/>Add SPARQL_UPDATE to roles using the menu at the bottom.
  * If no dba account exists, add one, then add update rights.
- 11. Start the SynBioHub process `npm start` or `npm run-script dev`
-
+ 7. Start the SynBioHub process `npm start` or `npm run-script dev`


### PR DESCRIPTION
The prerequisite section now has installation commands for both macOS and Ubuntu. I also made a section for installation steps on Ubuntu, installation steps on a Mac, and lastly a section for installation steps required on both systems. Hopefully, this updated README will be a lot easier to navigate for Mac users and remain simple to understand for Ubuntu users. (My original pull request was accepted but I couldn't merge with master because I had forked the repository and wasn't yet invited as a collaborator).