### PR TITLE
Overflow rendering

### DIFF
--- a/browser/synbiohub.js
+++ b/browser/synbiohub.js
@@ -2,7 +2,6 @@ $(document).on('click', '[data-uri]', function () {
     window.location = $(this).attr('data-uri')
 })
 
-
 $("body").tooltip({
     selector: '[data-toggle="tooltip"]',
     container: 'body'

--- a/public/styles/bootstrap/panels.less
+++ b/public/styles/bootstrap/panels.less
@@ -16,6 +16,7 @@
 .panel-body {
   padding: @panel-body-padding;
   &:extend(.clearfix all);
+  overflow: scroll;
 }
 
 // Optional heading

--- a/public/styles/site/synbiohub.less
+++ b/public/styles/site/synbiohub.less
@@ -657,7 +657,7 @@ input:-webkit-autofill, .sbol-login-text, .change_password input {
 }
 
 #design {
-    overflow-y: none;
+    overflow-y: hidden;
     overflow-x: scroll;
     margin-left: 20px;
 }

--- a/public/styles/site/synbiohub.less
+++ b/public/styles/site/synbiohub.less
@@ -656,8 +656,9 @@ input:-webkit-autofill, .sbol-login-text, .change_password input {
     color: #7F8C8D;
 }
 
-.row {
+.design-container {
     overflow-x: scroll;
+    overflow-y: hidden;
 }
 
 .search-results-area {

--- a/public/styles/site/synbiohub.less
+++ b/public/styles/site/synbiohub.less
@@ -656,10 +656,8 @@ input:-webkit-autofill, .sbol-login-text, .change_password input {
     color: #7F8C8D;
 }
 
-#design {
-    overflow-y: hidden;
+.row {
     overflow-x: scroll;
-    margin-left: 20px;
 }
 
 .search-results-area {

--- a/public/styles/site/synbiohub.less
+++ b/public/styles/site/synbiohub.less
@@ -656,6 +656,12 @@ input:-webkit-autofill, .sbol-login-text, .change_password input {
     color: #7F8C8D;
 }
 
+#design {
+    overflow-y: none;
+    overflow-x: scroll;
+    margin-left: 20px;
+}
+
 .search-results-area {
     width: 80%;
     margin: 0 auto;

--- a/templates/views/combinatorialderivation.jade
+++ b/templates/views/combinatorialderivation.jade
@@ -3,7 +3,7 @@ extends ../layouts/topLevel.jade
 
 block topLevelPreview
     if meta.displayList
-        div.row
+        div.design-container
             div.col-md-12.text-center
             div#design
 

--- a/templates/views/componentDefinition.jade
+++ b/templates/views/componentDefinition.jade
@@ -3,7 +3,7 @@ extends ../layouts/topLevel.jade
 
 block topLevelPreview
     if meta.displayList
-        div.row
+        div.design-container
             div.col-md-12.text-center
             div#design
 

--- a/templates/views/componentinstance.jade
+++ b/templates/views/componentinstance.jade
@@ -3,7 +3,7 @@ extends measured.jade
 
 block topLevelPreview
     if meta.displayList
-        div.row
+        div.design-container
             div.col-md-12.text-center
             div#design
 

--- a/templates/views/experiment.jade
+++ b/templates/views/experiment.jade
@@ -3,7 +3,7 @@ extends ../layouts/topLevel.jade
 
 block topLevelPreview
     if meta.displayList
-        div.row
+        div.design-container
             div.col-md-12.text-center
             div#design
 

--- a/templates/views/mapsto.jade
+++ b/templates/views/mapsto.jade
@@ -3,7 +3,7 @@ extends ../layouts/identified.jade
 
 block topLevelPreview
     if meta.displayList
-        div.row
+        div.design-container
             div.col-md-12.text-center
             div#design
 

--- a/templates/views/moduleDefinition.jade
+++ b/templates/views/moduleDefinition.jade
@@ -3,7 +3,7 @@ extends ../layouts/topLevel.jade
 
 block topLevelPreview
     if meta.displayList
-        div.row
+        div.design-container
             div.col-md-12.text-center
             div#design
 

--- a/templates/views/moduleinstance.jade
+++ b/templates/views/moduleinstance.jade
@@ -3,7 +3,7 @@ extends measured.jade
 
 block topLevelPreview
     if meta.displayList
-        div.row
+        div.design-container
             div.col-md-12.text-center
             div#design
 

--- a/templates/views/sequenceannotation.jade
+++ b/templates/views/sequenceannotation.jade
@@ -3,7 +3,7 @@ extends ../layouts/identified.jade
 
 block topLevelPreview
     if meta.displayList
-        div.row
+        div.design-container
             div.col-md-12.text-center
             div#design
 

--- a/templates/views/sequenceconstraint.jade
+++ b/templates/views/sequenceconstraint.jade
@@ -3,7 +3,7 @@ extends ../layouts/identified.jade
 
 block topLevelPreview
     if meta.displayList
-        div.row
+        div.design-container
             div.col-md-12.text-center
             div#design
 

--- a/templates/views/visualization.jade
+++ b/templates/views/visualization.jade
@@ -7,6 +7,6 @@ block body
 
     if meta.displayList
         div.container
-            div.row
+            div.design-container
                 div.col-md-12.text-center
                 div#design

--- a/tests/previousresults/getrequest_public-:collectionId-:displayId-:version-visualization_.html
+++ b/tests/previousresults/getrequest_public-:collectionId-:displayId-:version-visualization_.html
@@ -35,7 +35,7 @@ try {
  </head>
  <body>
   <div class="container">
-   <div class="row">
+   <div class="design-container">
     <div class="col-md-12 text-center">
     </div>
     <div id="design">

--- a/tests/previousresults/getrequest_public-:collectionId-:displayId_bbapublic.html
+++ b/tests/previousresults/getrequest_public-:collectionId-:displayId_bbapublic.html
@@ -254,7 +254,7 @@ try {
     <br/>
     <br/>
    </div>
-   <div class="row">
+   <div class="design-container">
     <div class="col-md-12 text-center">
     </div>
     <div id="design">


### PR DESCRIPTION
In this branch, I dealt with div overflows on Synbiohub. The info panels now scroll on overflow, as does the Visbol design (I added a new div called design-container within the jade files). This also gets rid of the Synbiohub Visbol tooltip rendering issue.