### PR TITLE
Fix pull token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
         - uses: actions/checkout@v2
           with:
+            persist-credentials: false
+            fetch-depth: 0
             repository: synbiohub/synbiohub-docker
         - name: Change tag
           run: |


### PR DESCRIPTION
The synbiohub-docker repository was pulled with the synbiohub repository credentials, which is why the push failed