### PR TITLE
Remove under-construction message

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ Additionally, they must pass Travis checks, which build a Docker image and run t
 Each time a PR is merged into master, the Travis checks are re-run on the master branch, and if they succeed the resulting image is pushed by Travis to DockerHub under the tag `snapshot-standalone`.
 
 ## Publishing a release
-This automation is currently *under construction*, so the process described below may not be completely implemented.
 Releases are published automatically using GitHub Actions. 
 There is an action which fires on release publication.
 It publishes an image to Docker Hub under the $VERSION-standalone tag, and updates the [synbiohub-docker](https://github.com/synbiohub/synbiohub-docker) master branch to point to this version.


### PR DESCRIPTION
Release is working, so removing the warning that things are under construction