### PR TITLE
Move from Travis to GH Actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,4 +1,8 @@
 # GitHub Actions
+## Test
+This is the workflow described in the file `test.yml`.
+It runs the SBH test suite, the SynBioHub test suite, and then if both succeed the image is pushed to Docker Hub.
+
 ## Release
 This is the workflow described in the file `release.yml`.
 It is composed of two jobs: `retag-release` and `update-compose`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
   publish:
     needs: [sboltests, sbhtests]
     runs-on: ubuntu-latest
+    if: endsWith(github.ref, "master")
     steps:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run release 
+name: Test and publish snapshot
 
 on: push
 
@@ -70,4 +70,10 @@ jobs:
     - name: Push the image to Docker Hub
       run: |
         docker push synbiohub/synbiohub:snapshot-standalone
-
+    - name: Trigger SD2 redeploy
+      env: 
+        SD2_USER: ${{ secrets.SD2_USER }}
+        SD2_TOKEN: ${{ secrets.SD2_TOKEN }}
+      run: | 
+        curl -X POST --user $SD2_USER:$SD2_TOKEN http://jenkins.sd2e.org/job/Synbiohub/job/Redeploy%20to%20dev%20server/build | 
+      curl -X POST --user $SD2_USER:$SD2_TOKEN http://jenkins.sd2e.org/job/Synbiohub/job/Redeploy%20to%20dev%20server/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
       run: |
         pip install -r tests/test_requirements.txt
     - name: Run tests
+      run: |
         tests/test.sh --stopaftertestsuite
   publish:
     needs: [sboltests, sbhtests]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
       run: |
         pip install -r tests/test_requirements.txt
     - name: Run tests
+      run: |
         tests/sbolsuite.sh
   sbhtests:
     needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.6.7' # To match the one in Travis
+        python-version: '3.6' # To match the one in Travis
     - name: Install test dependencies
       run: |
         pip install -r tests/test_requirements.txt
@@ -53,7 +53,7 @@ jobs:
         cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.6.7' # To match the one in Travis
+        python-version: '3.6' # To match the one in Travis
     - name: Install test dependencies
       run: |
         pip install -r tests/test_requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Import saved Docker image
       run: |
         cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.6.7' # To match the one in Travis
     - name: Install test dependencies
       run: |
         pip install -r tests/test_requirements.txt
@@ -48,6 +51,9 @@ jobs:
     - name: Import saved Docker image
       run: |
         cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.6.7' # To match the one in Travis
     - name: Install test dependencies
       run: |
         pip install -r tests/test_requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
   publish:
     needs: [sboltests, sbhtests]
     runs-on: ubuntu-latest
-    if: endsWith(github.ref, "master")
+    if: endsWith(github.ref, 'master')
     steps:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,70 @@
+name: Run release 
+
+on: push
+
+jobs:
+  build: 
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: |
+        docker build . --file docker/Dockerfile --tag synbiohub/synbiohub:snapshot-standalone
+    - name: Package image
+      run: |
+        docker save synbiohub/synbiohub:snapshot-standalone | gzip > sbh.tar.gz
+    - uses: actions/upload-artifact@v2
+      with:
+        name: sbh-image
+        path: sbh.tar.gz
+  sboltests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: sbh-image
+    - name: Import saved Docker image
+      run: |
+        cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
+    - name: Install test dependencies
+      run: |
+        pip install -r tests/test_requirements.txt
+    - name: Run tests
+        tests/sbolsuite.sh
+  sbhtests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: sbh-image
+    - name: Import saved Docker image
+      run: |
+        cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
+    - name: Install test dependencies
+      run: |
+        pip install -r tests/test_requirements.txt
+    - name: Run tests
+        tests/test.sh --stopaftertestsuite
+  publish:
+    needs: [sboltests, sbhtests]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: sbh-image
+    - name: Import saved Docker image
+      run: |
+        cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
+    - uses: azure/docker-login@v1
+      with: 
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Push the image to Docker Hub
+      run: |
+        docker push synbiohub/synbiohub:snapshot-standalone
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         name: sbh-image
     - name: Import saved Docker image
       run: |
-        cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
+        cat sbh.tar.gz | docker load
     - uses: actions/setup-python@v1
       with:
         python-version: '3.6' # To match the one in Travis
@@ -50,7 +50,7 @@ jobs:
         name: sbh-image
     - name: Import saved Docker image
       run: |
-        cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
+        cat sbh.tar.gz | docker load
     - uses: actions/setup-python@v1
       with:
         python-version: '3.6' # To match the one in Travis
@@ -72,7 +72,7 @@ jobs:
         name: sbh-image
     - name: Import saved Docker image
       run: |
-        cat sbh.tar.gz | docker import - synbiohub/synbiohub:snapshot-standalone
+        cat sbh.tar.gz | docker load
     - uses: azure/docker-login@v1
       with: 
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,4 +80,3 @@ jobs:
         SD2_TOKEN: ${{ secrets.SD2_TOKEN }}
       run: | 
         curl -X POST --user $SD2_USER:$SD2_TOKEN http://jenkins.sd2e.org/job/Synbiohub/job/Redeploy%20to%20dev%20server/build | 
-      curl -X POST --user $SD2_USER:$SD2_TOKEN http://jenkins.sd2e.org/job/Synbiohub/job/Redeploy%20to%20dev%20server/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   build: 
+    name: Build Docker image
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         name: sbh-image
         path: sbh.tar.gz
   sboltests:
+    name: SBOL Test Suite
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -35,6 +37,7 @@ jobs:
       run: |
         tests/sbolsuite.sh
   sbhtests:
+    name: SynBioHub Test Suite
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -52,6 +55,7 @@ jobs:
       run: |
         tests/test.sh --stopaftertestsuite
   publish:
+    name: Publish snapshot image
     needs: [sboltests, sbhtests]
     runs-on: ubuntu-latest
     if: endsWith(github.ref, 'master')


### PR DESCRIPTION
Duplicates the automation currently running in Travis to GitHub Actions. Once accepted, we can move over PR gating to the GitHub Actions and then delete the Travis configs entirely. 