### PR TITLE
Go fetch directly from the Web of Registries

### DIFF
--- a/lib/api/updateWebOfRegistries.js
+++ b/lib/api/updateWebOfRegistries.js
@@ -1,8 +1,14 @@
 const config = require('../config')
+const request = require('request')
+const util = require('util')
+const get = util.promisify(request.get)
 
-module.exports = function (req, res) {
-  let registries = req.body
+module.exports = async function (req, res) {
+  let worUrl = config.get('webOfRegistriesUrl')
   let current = config.get('webOfRegistries')
+
+  let instances = await get(worUrl + '/instances')
+  let registries = JSON.parse(instances.body)
 
   if (registries && registries instanceof Array) {
     registries.forEach(registry => {


### PR DESCRIPTION
Instead of getting the body directly from the update request, just go fetch from the Web of Registries when the endpoint it it. 

Closes #1213 