### PR TITLE
Eliminate CORS error for localhost:3000 (synbiohub3 frontend development server)

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -5,6 +5,18 @@ const config = require('./config')
 const initSSE = require('./sse').initSSE
 const cache = require('./cache')
 const setupAppMiddleware = require('./app-middleware')
+const cors = require('cors')
+
+var whitelist = ['http://localhost:7777', 'http://localhost:3000']
+var corsOptions = {
+  origin: function (origin, callback) {
+    if (!origin || whitelist.indexOf(origin) !== -1) {
+      callback(null, true)
+    } else {
+      callback(new Error('Not allowed by CORS: ' + origin))
+    }
+  }
+}
 
 const views = {
   index: require('./views/index'),
@@ -126,6 +138,8 @@ function App () {
   const app = express()
 
   setupAppMiddleware(app)
+
+  app.use(cors(corsOptions))
 
   const uploadToMemory = multer({
     storage: multer.memoryStorage({})

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "connect-flash": "^0.1.1",
     "connect-sequelize": "^2.0.2",
     "cookie-parser": "^1.4.1",
+    "cors": "^2.8.5",
     "crypto-random-string": "^3.0.1",
     "deepmerge": "^2.2.1",
     "doi-regex": "^0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,6 +2261,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@^5.0.7, cosmiconfig@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -5188,7 +5196,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -7513,7 +7521,7 @@ value-event@^5.1.1:
     global "^4.2.1"
     xtend "^2.2.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
Added localhost:7777 and localhost:3000 to list of acceptable origins that synbiohub.org can serve requests to (in the browser). This will allow the SynBioHub3 frontend development server to communicate directly with SynBioHub.org. It will also continue to allow all local synbiohubs running on port 7777 to carry on as usual. If you'd like, I can disable CORS errors for ALL origins, but I thought it made more sense to manually specify which origins are acceptable.