### PR TITLE
Allow open access to users list

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -265,7 +265,7 @@ function App () {
   app.get('/admin/theme', views.admin.theme)
   app.post('/admin/theme', requireAdmin, uploadToMemory.single('logo'), views.admin.theme)
 
-  app.get('/admin/users', requireAdmin, views.admin.users)
+  app.get('/admin/users', requirePublicLogin, views.admin.users)
   app.post('/admin/users', requireAdmin, views.admin.users)
   app.get('/admin/newUser', requireAdmin, views.admin.newUser)
   app.post('/admin/newUser', requireAdmin, bodyParser.urlencoded({ extended: true }), views.admin.newUser)


### PR DESCRIPTION
To test this, you should be able to get the user list without being logged in as an admin.  This should allow you to build the add owners list