### PR TITLE
Timeouts added to plugins

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -56,7 +56,7 @@ async function getPlugins (type) {
 
   let statuses = await Promise.all(plugins.map(plugin => {
     let statusUrl = plugin.url + 'status'
-    return get(statusUrl)
+    return get({ url: statusUrl, timeout: 5000 }) // 5 seconds timeout (Can be adjusted as needed)
       .then(response => response.statusCode < 300)
       .catch(err => {
         console.error(err)

--- a/lib/plugins/pluginEndpoints.js
+++ b/lib/plugins/pluginEndpoints.js
@@ -60,7 +60,8 @@ module.exports = function (req, res) {
     return axios({
       method: 'GET',
       url: pluginUrl + 'status',
-      responseType: 'text'
+      responseType: 'text',
+      timeout: 5000
     }).then(response => {
       return res.status(200).send(response.data)
     }).catch(error => {
@@ -89,7 +90,8 @@ module.exports = function (req, res) {
       },
       method: 'POST',
       url: pluginUrl + 'evaluate',
-      data: data
+      data: data,
+      timeout: 10000
     }).then(response => {
       if (category === 'submit') {
         res.header('Content-Type', 'application/json')
@@ -124,7 +126,8 @@ module.exports = function (req, res) {
       responseType: responseType,
       method: 'POST',
       url: pluginUrl + 'run',
-      data: pluginData
+      data: pluginData,
+      timeout: 60000
     }).then(response => {
       if (category === 'download') {
         const filename = response.headers['content-disposition'].split('=')[1]


### PR DESCRIPTION
Fixes the issue that plugins returning no response would lock up SBH1 and SBH2 for users. Issue logged in SBH3 repo (but fix was on backend)