### PR TITLE
Fix SPARQL queries that only worked under Virtuoso's lenient parser

### DIFF
--- a/lib/actions/makePublic.js
+++ b/lib/actions/makePublic.js
@@ -228,7 +228,7 @@ module.exports = function (req, res) {
         newRootCollectionDisplayId: collectionId + '_collection',
         newRootCollectionVersion: version,
         ownedByURI: config.get('databasePrefix') + 'user/' + req.params.userId,
-        creatorName: '',
+        creatorName: req.user.name,
         citationPubmedIDs: citations,
         overwrite_merge: overwriteMerge,
         user: apiTokens.createToken(req.user)

--- a/lib/fetch/local/fetch-sbol-object-recursive.js
+++ b/lib/fetch/local/fetch-sbol-object-recursive.js
@@ -349,7 +349,14 @@ return [
 '}'
 ]).join('\n') */
 
-  var from = 'FROM <' + config.get('databasePrefix') + 'public>' + ' FROM <' + graphUri + '>'
+  var from = 'FROM <' + config.get('databasePrefix') + 'public>'
+
+  // graphUri is null when resolving a purely public object. Only add the
+  // user-graph dataset clause when there is one; emitting `FROM <null>`
+  // produces an invalid (relative) IRI that a strict SPARQL parser rejects.
+  if (graphUri) {
+    from += ' FROM <' + graphUri + '>'
+  }
 
   var query = [
     isCount

--- a/sparql/AttachUpload.sparql
+++ b/sparql/AttachUpload.sparql
@@ -3,7 +3,7 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX sbh: <http://wiki.synbiohub.org/wiki/Terms/synbiohub#>
 PREFIX sbol: <http://sbols.org/v2#>
 
-INSERT {
+INSERT DATA {
     <$topLevel> sbol:attachment <$attachmentURI> .
 
     <$collectionUri> sbol:member <$attachmentURI> .

--- a/sparql/AttachUrl.sparql
+++ b/sparql/AttachUrl.sparql
@@ -2,7 +2,7 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX sbh: <http://wiki.synbiohub.org/wiki/Terms/synbiohub#>
 PREFIX sbol: <http://sbols.org/v2#>
 
-INSERT {
+INSERT DATA {
     <$topLevel> sbol:attachment <$uri> .
 
     <$collectionUri> sbol:member <$uri> .

--- a/sparql/searchCount.sparql
+++ b/sparql/searchCount.sparql
@@ -16,10 +16,11 @@ PREFIX so: <http://identifiers.org/so/>
 PREFIX bench: <http://wiki.synbiohub.org/wiki/Terms/benchling#>
 PREFIX genbank: <http://www.ncbi.nlm.nih.gov/genbank#>
 
-select (sum(?tempcount) as ?count) WHERE {
+select (sum(?tempcount) as ?count)
+$from
+WHERE {
 {
     SELECT (count(distinct ?subject) as ?tempcount)
-    $from
     WHERE {
         $criteria
 


### PR DESCRIPTION
Four SynBioHub bugs that Virtuoso tolerated but are invalid SPARQL / malformed data: FROM inside a subquery (searchCount), FROM <null> on public fetches, INSERT without DATA for attachments, and an empty dc:creator on makePublic. Each is corrected to valid SPARQL/data that works on Virtuoso and any standards-compliant store.