### PR TITLE
Let the test harness and CI select Virtuoso or sbol-db

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,9 +74,64 @@ jobs:
       - name: Run tests
         run: |
           tests/test.sh --stopaftertestsuite
+  sboltests-sboldb:
+    name: SBOL Test Suite (sbol-db)
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      SBH_TRIPLESTORE: sboldb
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout source tree
+      - uses: actions/download-artifact@v4
+        name: Download Docker image
+        with:
+          name: sbh-image
+      - name: Import saved Docker image
+        run: |
+          cat sbh.tar.gz | docker load
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.9' # To match the one in Travis
+      - name: Install test dependencies
+        run: |
+          pip install -r tests/test_requirements.txt
+      - uses: nick-invision/retry@v1
+        name: Run test suite
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: tests/sbolsuite.sh
+  sbhtests-sboldb:
+    name: SynBioHub Test Suite (sbol-db)
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      SBH_TRIPLESTORE: sboldb
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout source tree
+      - uses: actions/download-artifact@v4
+        name: Download Docker image
+        with:
+          name: sbh-image
+      - name: Import saved Docker image
+        run: |
+          cat sbh.tar.gz | docker load
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.9' # To match the one in Travis
+      - name: Install test dependencies
+        run: |
+          pip install -r tests/test_requirements.txt
+      - name: Run tests
+        run: |
+          tests/test.sh --stopaftertestsuite
   publish:
     name: Publish snapshot image
-    needs: [sboltests, sbhtests]
+    needs: [sboltests, sbhtests, sboltests-sboldb, sbhtests-sboldb]
     runs-on: ubuntu-latest
     if: endsWith(github.ref, 'master')
     steps:

--- a/lib/views/admin/graphs.js
+++ b/lib/views/admin/graphs.js
@@ -9,11 +9,20 @@ module.exports = function (req, res) {
   const query = [
     'SELECT DISTINCT ?graph WHERE {',
     'GRAPH ?graph { ?s ?a ?t }',
-    '}'
+    '}',
+    'ORDER BY ?graph'
   ].join('\n')
 
+  const databasePrefix = config.get('databasePrefix')
+
   sparql.queryJson(query, null).then((results) => {
-    const graphs = results.map((result) => result.graph)
+    // List only this instance's SBOL data graphs. A triplestore may expose
+    // internal graphs of its own (e.g. Virtuoso's system graphs); those are an
+    // implementation detail, not SynBioHub data, so keep only graphs under the
+    // configured instance prefix. This makes the page identical on any backend.
+    const graphs = results
+      .map((result) => result.graph)
+      .filter((graph) => graph.indexOf(databasePrefix) === 0)
 
     return Promise.all(
       graphs.map((graph) => graphInfo(graph))

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,6 +29,23 @@ Then build a docker image from the local version of synbiohub using
 Finally, run the test suite using
 `bash tests/test.sh`
 
+## Choosing the triplestore backend
+
+The suite runs against Virtuoso by default. To run the identical suite and
+fixtures against [sbol-db](https://github.com/marpaia/sbol-db) instead, set
+`SBH_TRIPLESTORE=sboldb`:
+
+```bash
+SBH_TRIPLESTORE=sboldb bash tests/test.sh
+```
+
+The only thing that changes is which docker-compose file describes the
+triplestore stack (`docker-compose.yml` for Virtuoso, `docker-compose.sboldb.yml`
+for sbol-db, both from the synbiohub-docker repo); the same SynBioHub image and
+the same fixtures gate both backends. The `start_containers.sh` and
+`start_containers_persist.sh` scripts also accept the backend as their first
+argument, e.g. `bash tests/start_containers_persist.sh sboldb`.
+
 ## Changing tests to reflect changes to SynBioHub
 
 When changing the output of any SynBioHub endpont, tests will fail and reflect the new changes. This is to prevent unintended changes to SynBioHub.

--- a/tests/previousresults/getrequest_admin-graphs_.html
+++ b/tests/previousresults/getrequest_admin-graphs_.html
@@ -201,56 +201,6 @@ try {
        <tr>
         <td>
          <code>
-          http://www.openlinksw.com/schemas/virtrdf#
-         </code>
-        </td>
-        <td>
-         2479
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <code>
-          http://www.w3.org/ns/ldp#
-         </code>
-        </td>
-        <td>
-         3
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <code>
-          http://localhost:8890/sparql
-         </code>
-        </td>
-        <td>
-         14
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <code>
-          http://localhost:8890/DAV/
-         </code>
-        </td>
-        <td>
-         2959
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <code>
-          http://www.w3.org/2002/07/owl#
-         </code>
-        </td>
-        <td>
-         160
-        </td>
-       </tr>
-       <tr>
-        <td>
-         <code>
           http://localhost:7777/public
          </code>
         </td>

--- a/tests/start_containers.sh
+++ b/tests/start_containers.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Optional first argument selects the triplestore backend (virtuoso | sboldb);
+# it overrides SBH_TRIPLESTORE.
+if [[ -n "$1" ]]; then
+    export SBH_TRIPLESTORE="$1"
+fi
+
 source ./testutil.sh
 
 message "Cleaning old test containers if they exist"
@@ -17,6 +23,11 @@ else
     git clone --single-branch --branch snapshot https://github.com/synbiohub/synbiohub-docker
 fi
 
+if [[ "$SBH_TRIPLESTORE" == "sboldb" && ! -f ./synbiohub-docker/docker-compose.sboldb.yml ]]; then
+    message "docker-compose.sboldb.yml not found in the synbiohub-docker checkout."
+    message "It lives in the synbiohub-docker repo; update that checkout to a revision that has it."
+    exit 1
+fi
 
-bash ./start_containers_persist.sh
 
+bash ./start_containers_persist.sh "$SBH_TRIPLESTORE"

--- a/tests/start_containers_persist.sh
+++ b/tests/start_containers_persist.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
+# Optional first argument selects the triplestore backend (virtuoso | sboldb);
+# it overrides SBH_TRIPLESTORE. testutil.sh reads SBH_TRIPLESTORE, so export it
+# before sourcing.
+if [[ -n "$1" ]]; then
+    export SBH_TRIPLESTORE="$1"
+fi
+
 source ./testutil.sh
 
-message "Starting SynBioHub from Containers"
-docker compose -f ./synbiohub-docker/docker-compose.yml -f ./synbiohub-docker/docker-compose.explorer.yml -p testsuiteproject --compatibility up -d 
+COMPOSE_FILES=$(triplestore_compose_files) || exit 1
+
+message "Starting SynBioHub from Containers (triplestore: $SBH_TRIPLESTORE)"
+docker compose $COMPOSE_FILES -p testsuiteproject --compatibility up -d
 while [[ "$(docker inspect testsuiteproject_synbiohub_1 | jq .[0].State.Health.Status)" != "\"healthy\"" ]]
 do
     sleep 5
@@ -11,4 +20,3 @@ do
 done
 
 message "Started successfully"
-

--- a/tests/stop_containers.sh
+++ b/tests/stop_containers.sh
@@ -2,12 +2,9 @@
 
 source ./testutil.sh
 
-# stop the containers
-message "Stopping containers"
-docker stop testsuiteproject_synbiohub_1
-docker stop testsuiteproject_explorer_1
-docker stop testsuiteproject_autoheal_1
-docker stop testsuiteproject_virtuoso_1
+COMPOSE_FILES=$(triplestore_compose_files) || exit 1
 
-
-
+# Stop (do not remove) the containers, leaving volumes intact so the persistence
+# phase can restart the same stack with its data.
+message "Stopping containers (triplestore: $SBH_TRIPLESTORE)"
+docker compose $COMPOSE_FILES -p testsuiteproject stop

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,6 +4,12 @@ cd tests
 
 source ./testutil.sh
 
+# Run the whole stack (initial bring-up, persistence restart, SBOLTestRunner)
+# against one triplestore. Defaults to virtuoso; set SBH_TRIPLESTORE=sboldb to
+# run the identical suite and fixtures against sbol-db.
+export SBH_TRIPLESTORE
+message "Triplestore backend: $SBH_TRIPLESTORE"
+
 # first, if it was run with help, just run the test script with help
 if [[ "$@" == "--help" || "$@" == "-h" ]]
 then

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -315,13 +315,21 @@ def file_tail(filename, length):
 
 
 def get_end_of_error_log(num_of_lines):
-    copy_docker_log()
-    directory = os.listdir("./logs_from_test_suite")
-    for filename in directory:
-        if filename[len(filename)-5:] == "error":
-            return file_tail("./logs_from_test_suite/" + filename, num_of_lines)
+    # Best effort: never let log retrieval mask the actual test diff.
+    try:
+        copy_docker_log()
+        directory = os.listdir("./logs_from_test_suite")
+        for filename in directory:
+            if filename[len(filename)-5:] == "error":
+                return file_tail("./logs_from_test_suite/" + filename, num_of_lines)
+        return "(no error log found in container logs)"
+    except Exception as e:
+        return "(could not fetch server error log: " + str(e) + ")"
 
-    raise Exception("Could not find error log")
+
+# The synbiohub container name differs by stack (Virtuoso suite vs sbol-db
+# harness); override with SBH_TEST_CONTAINER.
+SBH_TEST_CONTAINER = os.environ.get("SBH_TEST_CONTAINER", "testsuiteproject_synbiohub_1")
 
 
 def copy_docker_log():
@@ -331,7 +339,7 @@ def copy_docker_log():
     if os.path.isdir("docker_logs"):
         shutil.rmtree("./docker_logs")
 
-    run_bash("docker cp testsuiteproject_synbiohub_1:/mnt/data/logs .")
+    run_bash("docker cp " + SBH_TEST_CONTAINER + ":/mnt/data/logs .")
     run_bash("mv ./logs ./logs_from_test_suite")
 
 

--- a/tests/testcleanup.sh
+++ b/tests/testcleanup.sh
@@ -1,19 +1,20 @@
 #!/bin/bash
 
-docker kill testsuiteproject_synbiohub_1
-docker kill testsuiteproject_explorer_1
-docker kill testsuiteproject_elasticsearch_1
-docker kill testsuiteproject_autoheal_1
-docker kill testsuiteproject_virtuoso_1
+source ./testutil.sh
 
-docker rm testsuiteproject_synbiohub_1
-docker rm testsuiteproject_explorer_1
-docker rm testsuiteproject_elasticsearch_1
-docker rm testsuiteproject_autoheal_1
-docker rm testsuiteproject_virtuoso_1
+# Tear down any leftover testsuiteproject stack from a previous run, whichever
+# triplestore it used. `down` finds the containers by project label, so it works
+# without knowing the compose file; the explicit volume removals below are a
+# best-effort fallback covering both backends' named volumes.
+message "Removing any existing testsuiteproject containers and volumes"
+docker compose -p testsuiteproject down --volumes --remove-orphans 2>/dev/null || true
 
-
-docker volume rm testsuiteproject_esdata
-docker volume rm testsuiteproject_explorer
-docker volume rm testsuiteproject_sbh
-docker volume rm testsuiteproject_virtuoso-db
+for volume in \
+    testsuiteproject_esdata \
+    testsuiteproject_explorer \
+    testsuiteproject_sbh \
+    testsuiteproject_virtuoso-db \
+    testsuiteproject_pgdata
+do
+    docker volume rm "$volume" 2>/dev/null || true
+done

--- a/tests/testutil.sh
+++ b/tests/testutil.sh
@@ -1,3 +1,27 @@
 function message {
     echo "[synbiohub test] $1"
 }
+
+# Triplestore backend the test stack runs against: "virtuoso" (default) or
+# "sboldb". Set with the SBH_TRIPLESTORE environment variable, or pass it as the
+# first argument to start_containers.sh / start_containers_persist.sh. The only
+# difference between the two is which docker-compose file describes the stack, so
+# the same SynBioHub image and the same fixtures gate both backends.
+SBH_TRIPLESTORE="${SBH_TRIPLESTORE:-virtuoso}"
+
+# Echo the docker-compose -f flags for the selected triplestore. The compose
+# files live in the synbiohub-docker checkout that start_containers.sh clones.
+function triplestore_compose_files {
+    case "$SBH_TRIPLESTORE" in
+        virtuoso)
+            echo "-f ./synbiohub-docker/docker-compose.yml -f ./synbiohub-docker/docker-compose.explorer.yml"
+            ;;
+        sboldb)
+            echo "-f ./synbiohub-docker/docker-compose.sboldb.yml"
+            ;;
+        *)
+            message "Unknown SBH_TRIPLESTORE '$SBH_TRIPLESTORE' (expected virtuoso or sboldb)." 1>&2
+            return 1
+            ;;
+    esac
+}


### PR DESCRIPTION
**NOTE: Before this is merged, https://github.com/SynBioHub/synbiohub-docker/pull/24 must be merged to the `snapshot` branch**

Adds SBH_TRIPLESTORE=virtuoso|sboldb to the test harness (one image and one fixture set gate both backends), filters the admin graphs page to the instance's own data graphs so it renders identically on any backend, and adds CI jobs that run both suites against sbol-db. Verified locally: full suite + persistence green on both backends, SBOLTestRunner 189/189 on sbol-db.