### PR TITLE
Add conformance testing for Explorer search backends

### DIFF
--- a/.github/workflows/search-backend-conformance.yml
+++ b/.github/workflows/search-backend-conformance.yml
@@ -1,0 +1,218 @@
+name: Search backend conformance
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * 0'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: search-backend-conformance
+  cancel-in-progress: false
+
+env:
+  SYNBIOHUB_DOCKER_REF: marpaia/sbol-db-and-explorer
+  SBOL_TEST_SUITE_REVISION: 0044284331b2f915a6e4b9d50e1cbf3ea2f62dcd
+  SYNBIOHUB_CONFORMANCE_IMAGE: synbiohub/synbiohub:search-conformance
+
+jobs:
+  build:
+    name: Build SynBioHub image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+        name: Checkout SynBioHub
+      - name: Build Docker image
+        run: |
+          docker build . \
+            --file docker/Dockerfile \
+            --tag "$SYNBIOHUB_CONFORMANCE_IMAGE"
+      - name: Package Docker image
+        run: |
+          docker save "$SYNBIOHUB_CONFORMANCE_IMAGE" | gzip > sbh.tar.gz
+      - uses: actions/upload-artifact@v4
+        name: Upload Docker image
+        with:
+          name: search-conformance-sbh-image
+          path: sbh.tar.gz
+          retention-days: 1
+
+  sbolexplorer:
+    name: Full corpus (SBOLExplorer)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      COMPOSE_PROJECT_NAME: search-conformance-explorer
+      SYNBIOHUB_IMAGE: synbiohub/synbiohub:search-conformance
+      SYNBIOHUB_PORT: '37777'
+      TRIPLESTORE_PORT: '38890'
+      EXPLORER_PORT: '33162'
+      ELASTICSEARCH_PORT: '39200'
+    steps:
+      - uses: actions/checkout@v5
+        name: Checkout SynBioHub
+      - uses: actions/checkout@v5
+        name: Checkout SynBioHub Docker topologies
+        with:
+          repository: SynBioHub/synbiohub-docker
+          ref: ${{ env.SYNBIOHUB_DOCKER_REF }}
+          path: synbiohub-docker
+      - uses: actions/checkout@v5
+        name: Checkout pinned SBOLTestSuite corpus
+        with:
+          repository: SynBioDex/SBOLTestSuite
+          ref: ${{ env.SBOL_TEST_SUITE_REVISION }}
+          path: SBOLTestSuite
+      - uses: actions/download-artifact@v4
+        name: Download SynBioHub image
+        with:
+          name: search-conformance-sbh-image
+      - name: Import SynBioHub image
+        run: |
+          gzip --decompress --stdout sbh.tar.gz | docker load
+      - name: Create artifact directory
+        run: mkdir -p artifacts/search-backends
+      - name: Start sbol-db with SBOLExplorer
+        run: |
+          docker compose \
+            -f synbiohub-docker/docker-compose.sboldb.yml \
+            -f synbiohub-docker/docker-compose.sboldb-store-only.yml \
+            -f synbiohub-docker/docker-compose.explorer.yml \
+            up -d --wait --wait-timeout 600
+      - name: Run full-corpus SBOLExplorer baseline
+        run: |
+          python3 tests/search-backends/run-conformance.py \
+            --topology sboldb-explorer-fixed \
+            --base-url http://127.0.0.1:37777/ \
+            --corpus-root SBOLTestSuite \
+            --report artifacts/search-backends/sboldb-explorer-fixed.json
+      - name: Capture SBOLExplorer topology logs
+        if: always()
+        run: |
+          docker compose \
+            -f synbiohub-docker/docker-compose.sboldb.yml \
+            -f synbiohub-docker/docker-compose.sboldb-store-only.yml \
+            -f synbiohub-docker/docker-compose.explorer.yml \
+            logs --no-color > artifacts/search-backends/sboldb-explorer-fixed.compose.log 2>&1 || true
+      - name: Stop SBOLExplorer topology
+        if: always()
+        run: |
+          docker compose \
+            -f synbiohub-docker/docker-compose.sboldb.yml \
+            -f synbiohub-docker/docker-compose.sboldb-store-only.yml \
+            -f synbiohub-docker/docker-compose.explorer.yml \
+            down --volumes --remove-orphans
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: search-conformance-sbolexplorer
+          path: artifacts/search-backends/
+          if-no-files-found: error
+          retention-days: 30
+
+  sboldb:
+    name: Full corpus (sbol-db)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      COMPOSE_PROJECT_NAME: search-conformance-sboldb
+      SYNBIOHUB_IMAGE: synbiohub/synbiohub:search-conformance
+      SYNBIOHUB_PORT: '27777'
+      TRIPLESTORE_PORT: '28890'
+    steps:
+      - uses: actions/checkout@v5
+        name: Checkout SynBioHub
+      - uses: actions/checkout@v5
+        name: Checkout SynBioHub Docker topologies
+        with:
+          repository: SynBioHub/synbiohub-docker
+          ref: ${{ env.SYNBIOHUB_DOCKER_REF }}
+          path: synbiohub-docker
+      - uses: actions/checkout@v5
+        name: Checkout pinned SBOLTestSuite corpus
+        with:
+          repository: SynBioDex/SBOLTestSuite
+          ref: ${{ env.SBOL_TEST_SUITE_REVISION }}
+          path: SBOLTestSuite
+      - uses: actions/download-artifact@v4
+        name: Download SynBioHub image
+        with:
+          name: search-conformance-sbh-image
+      - name: Import SynBioHub image
+        run: |
+          gzip --decompress --stdout sbh.tar.gz | docker load
+      - name: Create artifact directory
+        run: mkdir -p artifacts/search-backends
+      - name: Start sbol-db native search topology
+        run: |
+          docker compose \
+            -f synbiohub-docker/docker-compose.sboldb.yml \
+            -f synbiohub-docker/docker-compose.sboldb-search.yml \
+            up -d --wait --wait-timeout 600
+      - name: Run full-corpus sbol-db candidate
+        run: |
+          python3 tests/search-backends/run-conformance.py \
+            --topology sboldb-native \
+            --base-url http://127.0.0.1:27777/ \
+            --metrics-url http://127.0.0.1:28890/metrics \
+            --corpus-root SBOLTestSuite \
+            --report artifacts/search-backends/sboldb-native.json
+      - name: Capture sbol-db topology logs
+        if: always()
+        run: |
+          docker compose \
+            -f synbiohub-docker/docker-compose.sboldb.yml \
+            -f synbiohub-docker/docker-compose.sboldb-search.yml \
+            logs --no-color > artifacts/search-backends/sboldb-native.compose.log 2>&1 || true
+      - name: Stop sbol-db topology
+        if: always()
+        run: |
+          docker compose \
+            -f synbiohub-docker/docker-compose.sboldb.yml \
+            -f synbiohub-docker/docker-compose.sboldb-search.yml \
+            down --volumes --remove-orphans
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: search-conformance-sboldb
+          path: artifacts/search-backends/
+          if-no-files-found: error
+          retention-days: 30
+
+  compare:
+    name: Compare full-corpus reports
+    needs: [sbolexplorer, sboldb]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        name: Checkout SynBioHub
+      - uses: actions/download-artifact@v4
+        name: Download SBOLExplorer report
+        with:
+          name: search-conformance-sbolexplorer
+          path: artifacts/search-backends/baseline
+      - uses: actions/download-artifact@v4
+        name: Download sbol-db report
+        with:
+          name: search-conformance-sboldb
+          path: artifacts/search-backends/candidate
+      - name: Compare backend reports
+        run: |
+          python3 tests/search-backends/compare-reports.py \
+            --baseline artifacts/search-backends/baseline/sboldb-explorer-fixed.json \
+            --candidate artifacts/search-backends/candidate/sboldb-native.json \
+            --output artifacts/search-backends/comparison.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: search-conformance-comparison
+          path: artifacts/search-backends/comparison.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Integration testing
 
 on: push
 
+env:
+  SYNBIOHUB_DOCKER_REF: marpaia/sbol-db-and-explorer
+
 jobs:
   build:
     name: Build Docker image
@@ -144,9 +147,58 @@ jobs:
       - name: Run tests
         run: |
           tests/test.sh --stopaftertestsuite
+  explorer-compatibility:
+    name: Explorer compatibility (${{ matrix.label }})
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Virtuoso + SBOLExplorer
+            store: virtuoso
+            search: sbol-explorer
+          - label: sbol-db + SBOLExplorer
+            store: sboldb
+            search: sbol-explorer
+          - label: sbol-db + sbol-db
+            store: sboldb
+            search: sbol-db
+    env:
+      SBH_TRIPLESTORE: ${{ matrix.store }}
+      SBH_SEARCH_BACKEND: ${{ matrix.search }}
+      SBH_DOCKER_DIR: ${{ github.workspace }}/synbiohub-docker
+      SBH_EXPLORER_INDEX_TIMEOUT: "600"
+    steps:
+      - uses: actions/checkout@v5
+        name: Checkout SynBioHub
+      - uses: actions/checkout@v5
+        name: Checkout SynBioHub Docker topologies
+        with:
+          repository: SynBioHub/synbiohub-docker
+          ref: ${{ env.SYNBIOHUB_DOCKER_REF }}
+          path: synbiohub-docker
+      - uses: actions/download-artifact@v4
+        name: Download Docker image
+        with:
+          name: sbh-image
+      - name: Import saved Docker image
+        run: |
+          gzip --decompress --stdout sbh.tar.gz | docker load
+      - uses: actions/setup-python@v6
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Install test dependencies
+        run: |
+          pip install -r tests/test_requirements.txt
+      - name: Run indexed Explorer HTML contract
+        run: |
+          tests/test.sh --stopaftertestsuite
   publish:
     name: Publish snapshot image
-    needs: [search-backend-harness, sboltests, sbhtests, sboltests-sboldb, sbhtests-sboldb]
+    needs: [search-backend-harness, sboltests, sbhtests, sboltests-sboldb, sbhtests-sboldb, explorer-compatibility]
     runs-on: ubuntu-latest
     if: endsWith(github.ref, 'master')
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
     name: Search backend harness unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         name: Checkout source tree
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           python-version: '3.9' # To match the integration-test jobs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,21 @@ jobs:
         with:
           name: sbh-image
           path: sbh.tar.gz
+  search-backend-harness:
+    name: Search backend harness unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout source tree
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.9' # To match the integration-test jobs
+      - name: Run search backend harness unit tests
+        run: |
+          python -m unittest \
+            tests/search-backends/test_run_conformance.py \
+            tests/search-backends/test_compare_reports.py
   sboltests:
     name: SBOL Test Suite
     needs: build
@@ -131,7 +146,7 @@ jobs:
           tests/test.sh --stopaftertestsuite
   publish:
     name: Publish snapshot image
-    needs: [sboltests, sbhtests, sboltests-sboldb, sbhtests-sboldb]
+    needs: [search-backend-harness, sboltests, sbhtests, sboltests-sboldb, sbhtests-sboldb]
     runs-on: ubuntu-latest
     if: endsWith(github.ref, 'master')
     steps:

--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
   "javaPath": "java",
   "SBOLExplorerEndpoint": "http://localhost:13162/",
   "useSBOLExplorer": true,
+  "SBOLExplorerFallback": true,
   "theme": "default",
   "themeParameters": {
       "default": {

--- a/lib/config.js
+++ b/lib/config.js
@@ -77,6 +77,45 @@ function mergeConfigs () {
   mergedConfig = deepmerge(config, localConfig, {
     arrayMerge: (dest, src) => src
   })
+  applyEnvironmentOverrides()
+}
+
+// Deployment-only overrides for the external search topology. These values
+// deliberately sit above config.local.json without being persisted back into
+// it, so the same SynBioHub image can be exercised against stock SBOLExplorer
+// and sbol-db's compatibility listener in isolated Compose projects.
+function applyEnvironmentOverrides () {
+  if (process.env.SBH_EXPLORER_ENDPOINT !== undefined) {
+    if (process.env.SBH_EXPLORER_ENDPOINT === '') {
+      throw new Error('SBH_EXPLORER_ENDPOINT cannot be empty')
+    }
+    mergedConfig.SBOLExplorerEndpoint = process.env.SBH_EXPLORER_ENDPOINT
+  }
+  if (process.env.SBH_USE_EXPLORER !== undefined) {
+    mergedConfig.useSBOLExplorer = parseEnvironmentBoolean(
+      'SBH_USE_EXPLORER', process.env.SBH_USE_EXPLORER)
+  }
+  if (process.env.SBH_EXPLORER_FALLBACK !== undefined) {
+    mergedConfig.SBOLExplorerFallback = parseEnvironmentBoolean(
+      'SBH_EXPLORER_FALLBACK', process.env.SBH_EXPLORER_FALLBACK)
+  }
+}
+
+function parseEnvironmentBoolean (name, value) {
+  switch (String(value).trim().toLowerCase()) {
+    case '1':
+    case 'true':
+    case 'yes':
+    case 'on':
+      return true
+    case '0':
+    case 'false':
+    case 'no':
+    case 'off':
+      return false
+    default:
+      throw new Error(name + ' must be a boolean (true/false, 1/0, yes/no, on/off)')
+  }
 }
 
 function saveLocalConfig () {

--- a/lib/search.js
+++ b/lib/search.js
@@ -103,6 +103,9 @@ function search (graphUri, criteria, offset, limit, user, explorer = false) {
   }).catch((err) => {
     console.error('Virtuoso not responding search')
     console.error(err.stack)
+    if (explorer && config.get('SBOLExplorerFallback') === false) {
+      return Promise.reject(err)
+    }
     return Promise.resolve({ count: 0, results: [] })
   })
 }

--- a/lib/sparql/sparql.js
+++ b/lib/sparql/sparql.js
@@ -140,6 +140,10 @@ function queryJson (sparql, graphUri, explorer = false) {
 
   function handleError (error) {
     if (explorer) {
+      if (config.get('SBOLExplorerFallback') === false) {
+        console.error(error + ' -> SBOLExplorer fallback disabled')
+        return Promise.reject(error)
+      }
       console.log(error + ' -> retrying query with SBOLExplorer bypassed')
       return query(sparql, graphUri, 'application/sparql-results+json', false).then(parseResult).catch((err) => {
         console.error('Virtuoso not responding search')

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,22 +29,48 @@ Then build a docker image from the local version of synbiohub using
 Finally, run the test suite using
 `bash tests/test.sh`
 
-## Choosing the triplestore backend
+## Choosing the store and search backends
 
 The suite runs against Virtuoso by default. To run the identical suite and
 fixtures against [sbol-db](https://github.com/marpaia/sbol-db) instead, set
 `SBH_TRIPLESTORE=sboldb`:
 
 ```bash
-SBH_TRIPLESTORE=sboldb bash tests/test.sh
+SBH_TRIPLESTORE=sboldb SBH_SEARCH_BACKEND=none bash tests/test.sh
 ```
 
-The only thing that changes is which docker-compose file describes the
-triplestore stack (`docker-compose.yml` for Virtuoso, `docker-compose.sboldb.yml`
-for sbol-db, both from the synbiohub-docker repo); the same SynBioHub image and
-the same fixtures gate both backends. The `start_containers.sh` and
-`start_containers_persist.sh` scripts also accept the backend as their first
-argument, e.g. `bash tests/start_containers_persist.sh sboldb`.
+`SBH_SEARCH_BACKEND` is independent of the store and accepts `none` (the
+historical default), `external` (SBOLExplorer), or `native` (sbol-db's
+SBOLExplorer-compatible listener). Native search requires the sbol-db store.
+The two Explorer-enabled rows explicitly request an index update, wait for that
+specific operation to finish, and compare the complete `/search/I0462` HTML to
+the existing snapshot:
+
+```bash
+# Virtuoso plus external SBOLExplorer
+SBH_TRIPLESTORE=virtuoso SBH_SEARCH_BACKEND=external bash tests/test.sh
+
+# sbol-db as store plus external SBOLExplorer
+SBH_TRIPLESTORE=sboldb SBH_SEARCH_BACKEND=external bash tests/test.sh
+
+# sbol-db in both store and Explorer roles
+SBH_TRIPLESTORE=sboldb SBH_SEARCH_BACKEND=native bash tests/test.sh
+```
+
+The selected pair only changes the Compose files; every row uses the same
+SynBioHub image and fixtures. Set `SBH_DOCKER_DIR` to test an unmerged local
+synbiohub-docker checkout rather than the managed `tests/synbiohub-docker`
+clone:
+
+```bash
+SBH_DOCKER_DIR=/Users/marpaia/git/SynBioHub/synbiohub-docker \
+SBH_TRIPLESTORE=sboldb \
+SBH_SEARCH_BACKEND=native \
+bash tests/test.sh
+```
+
+The `start_containers.sh` and `start_containers_persist.sh` scripts still accept
+the store backend as their first argument for compatibility.
 
 ## Changing tests to reflect changes to SynBioHub
 
@@ -105,6 +131,5 @@ If you are making a change that should be ignored by the test suite for a very g
 
   --stopafterstart      do not run the test suite, just start up a new test
                         synbiohub instance.
-
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,21 +40,22 @@ SBH_TRIPLESTORE=sboldb SBH_SEARCH_BACKEND=none bash tests/test.sh
 ```
 
 `SBH_SEARCH_BACKEND` is independent of the store and accepts `none` (the
-historical default), `external` (SBOLExplorer), or `native` (sbol-db's
-SBOLExplorer-compatible listener). Native search requires the sbol-db store.
+historical default), `sbol-explorer` (SBOLExplorer), or `sbol-db` (sbol-db's
+SBOLExplorer-compatible listener). The `sbol-db` search backend requires the
+sbol-db store.
 The two Explorer-enabled rows explicitly request an index update, wait for that
 specific operation to finish, and compare the complete `/search/I0462` HTML to
 the existing snapshot:
 
 ```bash
-# Virtuoso plus external SBOLExplorer
-SBH_TRIPLESTORE=virtuoso SBH_SEARCH_BACKEND=external bash tests/test.sh
+# Virtuoso plus SBOLExplorer
+SBH_TRIPLESTORE=virtuoso SBH_SEARCH_BACKEND=sbol-explorer bash tests/test.sh
 
-# sbol-db as store plus external SBOLExplorer
-SBH_TRIPLESTORE=sboldb SBH_SEARCH_BACKEND=external bash tests/test.sh
+# sbol-db as store plus SBOLExplorer
+SBH_TRIPLESTORE=sboldb SBH_SEARCH_BACKEND=sbol-explorer bash tests/test.sh
 
 # sbol-db in both store and Explorer roles
-SBH_TRIPLESTORE=sboldb SBH_SEARCH_BACKEND=native bash tests/test.sh
+SBH_TRIPLESTORE=sboldb SBH_SEARCH_BACKEND=sbol-db bash tests/test.sh
 ```
 
 The selected pair only changes the Compose files; every row uses the same
@@ -65,7 +66,7 @@ clone:
 ```bash
 SBH_DOCKER_DIR=/Users/marpaia/git/SynBioHub/synbiohub-docker \
 SBH_TRIPLESTORE=sboldb \
-SBH_SEARCH_BACKEND=native \
+SBH_SEARCH_BACKEND=sbol-db \
 bash tests/test.sh
 ```
 
@@ -131,5 +132,4 @@ If you are making a change that should be ignored by the test suite for a very g
 
   --stopafterstart      do not run the test suite, just start up a new test
                         synbiohub instance.
-
 

--- a/tests/search-backends/README.md
+++ b/tests/search-backends/README.md
@@ -20,6 +20,19 @@ Accepted empty documents remain recorded but are correctly non-probeable. The
 run also verifies private search visibility, anonymous isolation,
 private-to-public publication, removal, and an observable index completion.
 
+## Automation
+
+The `Integration testing` workflow runs the focused indexed-HTML contract on
+every push for Virtuoso with SBOLExplorer, sbol-db with SBOLExplorer, and
+sbol-db with its compatibility listener. Each row explicitly rebuilds the
+configured index and compares the complete `/search/I0462` HTML snapshot.
+
+The `Search backend conformance` workflow runs the full pinned corpus every
+Sunday and on manual dispatch. It runs the SBOLExplorer baseline and sbol-db
+candidate on separate runners, uploads both JSON reports and their Compose
+logs, and then uploads the comparison report. Each workflow's
+`SYNBIOHUB_DOCKER_REF` selects its companion topology revision.
+
 ## Run one topology
 
 For the native sbol-db row, pass the main listener's metrics endpoint so job

--- a/tests/search-backends/README.md
+++ b/tests/search-backends/README.md
@@ -1,0 +1,86 @@
+# Search-backend conformance matrix
+
+This harness evaluates the Explorer role behind classic SynBioHub without
+allowing SynBioHub to silently retry failed Explorer queries against its store.
+The topology itself must set `SBH_EXPLORER_FALLBACK=false`.
+
+The full run is the principal gate. It pins SBOLTestSuite revision
+`0044284331b2f915a6e4b9d50e1cbf3ea2f62dcd` and attempts all 291 XML documents
+currently found under `SBOL2`, `SBOL2_bp`, `SBOL2_ic`, and `SBOL2_nc`. Invalid
+or incomplete inputs may be rejected by SynBioHub; the report preserves every
+outcome so the same acceptance boundary can be compared across topologies.
+
+Each accepted document with at least one imported member contributes its own
+search probe. Before querying search, the harness downloads that document's
+collection SBOL and selects a direct member from store-backed collection
+membership. The report records the download hash, membership counts, and exact
+post-import member. This matters because SynBioHub can discard external top
+levels, prefix generic display IDs, and normalize invalid URNs during import.
+Accepted empty documents remain recorded but are correctly non-probeable. The
+run also verifies private search visibility, anonymous isolation,
+private-to-public publication, removal, and an observable index completion.
+
+## Run one topology
+
+For the native sbol-db row, pass the main listener's metrics endpoint so job
+completion is observable:
+
+```sh
+python3 tests/search-backends/run-conformance.py \
+  --topology sboldb-native \
+  --base-url http://127.0.0.1:27777/ \
+  --metrics-url http://127.0.0.1:18890/metrics \
+  --corpus-root /Users/marpaia/git/SynBioDex/SBOLTestSuite \
+  --report artifacts/search-backends/sboldb-native.json
+```
+
+The fixed SBOLExplorer row obtains completion evidence through Explorer's
+indexing log:
+
+```sh
+python3 tests/search-backends/run-conformance.py \
+  --topology sboldb-explorer-fixed \
+  --base-url http://127.0.0.1:37777/ \
+  --corpus-root /Users/marpaia/git/SynBioDex/SBOLTestSuite \
+  --report artifacts/search-backends/sboldb-explorer-fixed.json
+```
+
+`--smoke` selects four documents, one from each corpus category. Smoke mode is
+useful for debugging but deliberately fails `full_corpus_coverage` and can
+never satisfy the required native gate.
+
+Corpus probes retain the first 50 ranked rows for parity comparison, then page
+through a bounded 10,000-row window only until they find the exact URI and
+display ID selected by the independent collection oracle. This accommodates
+large result sets without mistaking a duplicate ID from another submitted
+document for success. If only probe logic changes after an expensive full
+import, reuse the immutable submission, lifecycle, and index evidence while
+re-running every collection download and live search query:
+
+```sh
+python3 tests/search-backends/run-conformance.py \
+  --topology sboldb-native \
+  --base-url http://127.0.0.1:27777/ \
+  --metrics-url http://127.0.0.1:18890/metrics \
+  --corpus-root /Users/marpaia/git/SynBioDex/SBOLTestSuite \
+  --reprobe-from artifacts/search-backends/sboldb-native.json \
+  --report artifacts/search-backends/sboldb-native-reprobed.json
+```
+
+## Compare reports
+
+```sh
+python3 tests/search-backends/compare-reports.py \
+  --baseline artifacts/search-backends/sboldb-explorer-fixed.json \
+  --candidate artifacts/search-backends/sboldb-native.json \
+  --output artifacts/search-backends/comparison.json
+```
+
+The comparison records submission and search-result differences and applies a
+pinned-corpus compatibility policy. Both lifecycle gates and identical
+submission outcomes are required; at least 90% of complete first-page result
+sets must agree, no more than two probes may have count drift, and either drift
+may be at most one result. Exact top-ten order remains diagnostic because
+SBOLExplorer and sbol-db intentionally use different ranking implementations.
+This boundary catches tokenizer explosions and missing ontology enrichment
+without pretending the two rankers are byte-identical.

--- a/tests/search-backends/backend-manifest.json
+++ b/tests/search-backends/backend-manifest.json
@@ -1,0 +1,25 @@
+{
+  "corpus": {
+    "repository": "https://github.com/SynBioDex/SBOLTestSuite.git",
+    "revision": "0044284331b2f915a6e4b9d50e1cbf3ea2f62dcd",
+    "directories": ["SBOL2", "SBOL2_bp", "SBOL2_ic", "SBOL2_nc"],
+    "extensions": [".xml"]
+  },
+  "topologies": {
+    "virtuoso-explorer": {
+      "store": "Virtuoso",
+      "explorer": "SBOLExplorer",
+      "required": false
+    },
+    "sboldb-explorer-fixed": {
+      "store": "sbol-db",
+      "explorer": "SBOLExplorer with only documented bounded fixes",
+      "required": false
+    },
+    "sboldb-native": {
+      "store": "sbol-db",
+      "explorer": "sbol-db Explorer compatibility listener",
+      "required": true
+    }
+  }
+}

--- a/tests/search-backends/compare-reports.py
+++ b/tests/search-backends/compare-reports.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Compare diagnostic Explorer reports with the required native sbol-db row."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+MIN_EXACT_FIRST_PAGE_RATIO = 0.90
+MAX_COUNT_DIFFERENCE_PROBES = 2
+MAX_ABSOLUTE_COUNT_DELTA = 1
+
+
+def status_class(status: int | None) -> int | None:
+    return status // 100 if status is not None else None
+
+
+def result_signature(result: dict[str, object]) -> tuple[object, ...]:
+    return (
+        result.get("uri_path"),
+        result.get("displayId"),
+        result.get("name"),
+        result.get("type"),
+        result.get("version"),
+    )
+
+
+def signature_sort_key(signature: tuple[object, ...]) -> tuple[str, ...]:
+    return tuple("" if value is None else str(value) for value in signature)
+
+
+def keyed(report: dict[str, object], field: str) -> dict[str, dict[str, object]]:
+    return {str(entry["path"]): entry for entry in report[field]}
+
+
+def evaluate_parity(
+    corpus_equal: bool,
+    baseline_gate_passed: bool,
+    candidate_gate_passed: bool,
+    summary: dict[str, int | float],
+    probe_differences: list[dict[str, object]],
+) -> dict[str, object]:
+    """Apply a pinned-corpus compatibility policy without requiring ES order.
+
+    sbol-db and SBOLExplorer use different ranking implementations, so exact
+    top-ten order is diagnostic evidence rather than a compatibility gate. The
+    policy does require almost all complete first pages to agree, tightly
+    bounds count drift, and independently requires both lifecycle suites.
+    """
+    compared = int(summary["compared_probe_count"])
+    exact = int(summary["exact_first_page_parity_count"])
+    exact_ratio = exact / compared if compared else 0.0
+    count_deltas = [
+        abs(int(difference["baseline_count"]) - int(difference["candidate_count"]))
+        for difference in probe_differences
+        if difference.get("baseline_count") is not None
+        and difference.get("candidate_count") is not None
+        and difference["baseline_count"] != difference["candidate_count"]
+    ]
+    max_count_delta = max(count_deltas, default=0)
+    checks = {
+        "same_pinned_corpus": corpus_equal,
+        "baseline_conformance_passed": baseline_gate_passed,
+        "candidate_conformance_passed": candidate_gate_passed,
+        "submission_outcomes_identical": summary["submission_difference_count"] == 0,
+        "exact_first_page_ratio_at_least_90_percent": (
+            exact_ratio >= MIN_EXACT_FIRST_PAGE_RATIO
+        ),
+        "count_difference_probes_at_most_2": (
+            summary["count_difference_count"] <= MAX_COUNT_DIFFERENCE_PROBES
+        ),
+        "maximum_count_delta_at_most_1": max_count_delta <= MAX_ABSOLUTE_COUNT_DELTA,
+    }
+    return {
+        "checks": checks,
+        "passed": all(checks.values()),
+        "observed": {
+            "exact_first_page_ratio": exact_ratio,
+            "maximum_count_delta": max_count_delta,
+        },
+        "policy": {
+            "minimum_exact_first_page_ratio": MIN_EXACT_FIRST_PAGE_RATIO,
+            "maximum_count_difference_probes": MAX_COUNT_DIFFERENCE_PROBES,
+            "maximum_absolute_count_delta": MAX_ABSOLUTE_COUNT_DELTA,
+            "top_10_order_is_diagnostic_only": True,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    baseline = json.loads(args.baseline.read_text())
+    candidate = json.loads(args.candidate.read_text())
+    corpus_equal = all(
+        baseline["corpus"].get(key) == candidate["corpus"].get(key)
+        for key in (
+            "revision",
+            "discovered_xml_documents",
+            "selected_xml_documents",
+            "manifest_sha256",
+        )
+    )
+
+    baseline_submissions = keyed(baseline, "submissions")
+    candidate_submissions = keyed(candidate, "submissions")
+    submission_differences = []
+    for path in sorted(set(baseline_submissions) | set(candidate_submissions)):
+        left = baseline_submissions.get(path, {})
+        right = candidate_submissions.get(path, {})
+        if status_class(left.get("status")) != status_class(right.get("status")):
+            submission_differences.append(
+                {
+                    "path": path,
+                    "baseline_status": left.get("status"),
+                    "candidate_status": right.get("status"),
+                }
+            )
+
+    baseline_probes = keyed(baseline, "probes")
+    candidate_probes = keyed(candidate, "probes")
+    compared_probe_paths = set(baseline_probes) | set(candidate_probes)
+    probe_differences = []
+    for path in sorted(compared_probe_paths):
+        left = baseline_probes.get(path, {})
+        right = candidate_probes.get(path, {})
+        left_set = {result_signature(row) for row in left.get("results", [])}
+        right_set = {result_signature(row) for row in right.get("results", [])}
+        if left.get("count") != right.get("count") or left_set != right_set:
+            probe_differences.append(
+                {
+                    "path": path,
+                    "baseline_count": left.get("count"),
+                    "candidate_count": right.get("count"),
+                    "only_baseline": [
+                        list(item)
+                        for item in sorted(
+                            left_set - right_set, key=signature_sort_key
+                        )
+                    ],
+                    "only_candidate": [
+                        list(item)
+                        for item in sorted(
+                            right_set - left_set, key=signature_sort_key
+                        )
+                    ],
+                    "top_10_order_equal": [
+                        result_signature(row) for row in left.get("results", [])[:10]
+                    ]
+                    == [result_signature(row) for row in right.get("results", [])[:10]],
+                }
+            )
+
+    summary = {
+        "submission_difference_count": len(submission_differences),
+        "compared_probe_count": len(compared_probe_paths),
+        "exact_first_page_parity_count": len(compared_probe_paths)
+        - len(probe_differences),
+        "probe_difference_count": len(probe_differences),
+        "count_difference_count": sum(
+            difference["baseline_count"] != difference["candidate_count"]
+            for difference in probe_differences
+        ),
+        "top_10_order_difference_count": sum(
+            difference["top_10_order_equal"] is False
+            for difference in probe_differences
+        ),
+    }
+    parity_gate = evaluate_parity(
+        corpus_equal,
+        baseline["gate"]["passed"],
+        candidate["gate"]["passed"],
+        summary,
+        probe_differences,
+    )
+    output = {
+        "schema_version": 3,
+        "baseline": baseline["topology"],
+        "candidate": candidate["topology"],
+        "corpus_equal": corpus_equal,
+        "submission_outcome_differences": submission_differences,
+        "probe_differences": probe_differences,
+        "summary": summary,
+        "baseline_gate": baseline["gate"],
+        "candidate_gate": candidate["gate"],
+        "parity_gate": parity_gate,
+        "passed": parity_gate["passed"],
+        "note": (
+            "Exact top-ten order remains diagnostic because the implementations "
+            "use different rankers; lifecycle, result coverage, first-page set "
+            "agreement, and tightly bounded count drift are required."
+        ),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n")
+    print(
+        json.dumps(
+            {
+                "passed": output["passed"],
+                "corpus_equal": corpus_equal,
+                "baseline_gate_passed": baseline["gate"]["passed"],
+                "candidate_gate_passed": candidate["gate"]["passed"],
+                "parity_gate": parity_gate,
+                "summary": summary,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if output["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/search-backends/run-conformance.py
+++ b/tests/search-backends/run-conformance.py
@@ -1,0 +1,889 @@
+#!/usr/bin/env python3
+"""Exercise one classic-SynBioHub search topology and write an evidence report.
+
+The required mode attempts every XML file in the pinned SBOLTestSuite SBOL2
+corpus.  ``--smoke`` is intentionally diagnostic: it never satisfies the full
+coverage gate, even when all of its checks pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import mimetypes
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Iterable
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+import xml.etree.ElementTree as ET
+
+
+HERE = Path(__file__).resolve().parent
+MANIFEST_PATH = HERE / "backend-manifest.json"
+TOP_LEVELS = {
+    "Activity",
+    "Agent",
+    "Attachment",
+    "Collection",
+    "CombinatorialDerivation",
+    "ComponentDefinition",
+    "Experiment",
+    "ExperimentalData",
+    "GenericTopLevel",
+    "Implementation",
+    "Model",
+    "ModuleDefinition",
+    "Plan",
+    "Sequence",
+}
+RDF_ABOUT = "{http://www.w3.org/1999/02/22-rdf-syntax-ns#}about"
+RDF_RESOURCE = "{http://www.w3.org/1999/02/22-rdf-syntax-ns#}resource"
+SMOKE_PATHS = (
+    "SBOL2/BBa_I0462.xml",
+    "SBOL2_bp/BBa_T9002.xml",
+    "SBOL2_ic/CollectionOutput.xml",
+    "SBOL2_nc/BBa_I0462_orig.xml",
+)
+
+
+@dataclasses.dataclass
+class Response:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+    @property
+    def text(self) -> str:
+        return self.body.decode("utf-8", errors="replace")
+
+
+class Client:
+    def __init__(self, base_url: str, timeout: float):
+        self.base_url = base_url.rstrip("/") + "/"
+        self.timeout = timeout
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: dict[str, str] | None = None,
+        fields: dict[str, str] | None = None,
+        files: dict[str, Path] | None = None,
+    ) -> Response:
+        request_headers = dict(headers or {})
+        data: bytes | None = None
+        if files:
+            data, content_type = encode_multipart(fields or {}, files)
+            request_headers["Content-Type"] = content_type
+        elif fields is not None:
+            data = urllib.parse.urlencode(fields).encode()
+            request_headers["Content-Type"] = "application/x-www-form-urlencoded"
+        url = urllib.parse.urljoin(self.base_url, path.lstrip("/"))
+        req = urllib.request.Request(
+            url, data=data, headers=request_headers, method=method.upper()
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as result:
+                return Response(
+                    result.status, dict(result.headers.items()), result.read()
+                )
+        except urllib.error.HTTPError as error:
+            return Response(error.code, dict(error.headers.items()), error.read())
+
+
+def encode_multipart(
+    fields: dict[str, str], files: dict[str, Path]
+) -> tuple[bytes, str]:
+    boundary = "----sbh-search-" + uuid.uuid4().hex
+    chunks: list[bytes] = []
+    for name, value in fields.items():
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode(),
+                str(value).encode(),
+                b"\r\n",
+            ]
+        )
+    for name, path in files.items():
+        content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                (
+                    f'Content-Disposition: form-data; name="{name}"; '
+                    f'filename="{path.name}"\r\n'
+                ).encode(),
+                f"Content-Type: {content_type}\r\n\r\n".encode(),
+                path.read_bytes(),
+                b"\r\n",
+            ]
+        )
+    chunks.append(f"--{boundary}--\r\n".encode())
+    return b"".join(chunks), f"multipart/form-data; boundary={boundary}"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def git_revision(path: Path) -> str:
+    return subprocess.check_output(
+        ["git", "-C", str(path), "rev-parse", "HEAD"], text=True
+    ).strip()
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def probe_display_id(path: Path) -> str | None:
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError:
+        return None
+    for element in root.iter():
+        if local_name(element.tag) not in TOP_LEVELS:
+            continue
+        for child in element:
+            if local_name(child.tag) == "displayId" and child.text:
+                value = child.text.strip()
+                if value:
+                    return value
+    return None
+
+
+def corpus_files(root: Path, directories: Iterable[str]) -> list[Path]:
+    return sorted(
+        path
+        for directory in directories
+        for path in (root / directory).rglob("*.xml")
+        if path.is_file()
+    )
+
+
+def token_headers(token: str | None, accept: str = "text/plain") -> dict[str, str]:
+    headers = {"Accept": accept}
+    if token:
+        headers["X-authorization"] = token
+    return headers
+
+
+def login(client: Client, username: str, password: str) -> str | None:
+    response = client.request(
+        "POST",
+        "/login",
+        headers={"Accept": "text/plain"},
+        fields={"email": username, "password": password},
+    )
+    token = response.text.strip()
+    if response.status == 200 and re.fullmatch(
+        r"[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}", token
+    ):
+        return token
+    return None
+
+
+def ensure_setup(client: Client, args: argparse.Namespace) -> str:
+    token = login(client, args.username, args.password)
+    if token:
+        return token
+    response = client.request(
+        "POST",
+        "/setup",
+        headers={"Accept": "text/plain"},
+        fields={
+            "userName": args.username,
+            "userFullName": "Search Backend Test User",
+            "userEmail": args.email,
+            "userPassword": args.password,
+            "userPasswordConfirm": args.password,
+            "instanceName": f"Search backend evaluation: {args.topology}",
+            "instanceUrl": client.base_url,
+            "uriPrefix": client.base_url,
+            "color": "#D25627",
+            "frontPageText": "search-backend-evaluation",
+            "virtuosoINI": "/etc/virtuoso-opensource-7/virtuoso.ini",
+            "virtuosoDB": "/var/lib/virtuoso-opensource-7/db",
+            "allowPublicSignup": "true",
+        },
+    )
+    if response.status != 200 or "Setup Successful" not in response.text:
+        raise RuntimeError(
+            f"unable to initialize instance: HTTP {response.status}: {response.text[:500]}"
+        )
+    token = login(client, args.username, args.password)
+    if not token:
+        raise RuntimeError("setup succeeded but login did not return an API token")
+    return token
+
+
+def submit(
+    client: Client,
+    token: str,
+    source: Path,
+    collection_id: str,
+    overwrite: str = "0",
+) -> Response:
+    return client.request(
+        "POST",
+        "/submit",
+        headers=token_headers(token),
+        fields={
+            "id": collection_id,
+            "version": "1",
+            "name": collection_id,
+            "description": f"search backend fixture from {source.name}",
+            "citations": "",
+            "overwrite_merge": overwrite,
+        },
+        files={"file": source},
+    )
+
+
+def normalized_results(response: Response) -> tuple[list[dict[str, object]], str | None]:
+    if response.status != 200:
+        return [], f"HTTP {response.status}: {response.text[:500]}"
+    try:
+        decoded = json.loads(response.text)
+    except json.JSONDecodeError as error:
+        return [], f"invalid JSON: {error}: {response.text[:500]}"
+    if not isinstance(decoded, list):
+        return [], f"expected result list, got {type(decoded).__name__}"
+    normalized = []
+    for row in decoded:
+        uri = str(row.get("uri", ""))
+        parsed = urllib.parse.urlsplit(uri)
+        normalized.append(
+            {
+                "uri_path": parsed.path or uri,
+                "displayId": row.get("displayId", ""),
+                "name": row.get("name", ""),
+                "type": row.get("type", ""),
+                "version": row.get("version", ""),
+            }
+        )
+    return normalized, None
+
+
+def parse_collection_oracle(
+    body: bytes,
+    collection_id: str,
+    source_display_id: str | None,
+) -> dict[str, object]:
+    """Select a direct post-import member without consulting search.
+
+    SynBioHub may discard external top levels, prefix generic display IDs, or
+    normalize invalid URNs while importing a submission. The collection SBOL
+    download is generated from store membership, so it is an independent
+    oracle for the object that the search backend should return.
+    """
+    root = ET.fromstring(body)
+    root_display_id = f"{collection_id}_collection"
+    descriptions: dict[str, dict[str, str]] = {}
+    collection = None
+    for element in list(root):
+        uri = element.get(RDF_ABOUT)
+        if not uri:
+            continue
+        display_id = next(
+            (
+                child.text.strip()
+                for child in element
+                if local_name(child.tag) == "displayId"
+                and child.text
+                and child.text.strip()
+            ),
+            "",
+        )
+        descriptions[uri] = {
+            "display_id": display_id,
+            "type": local_name(element.tag),
+            "uri_path": urllib.parse.urlsplit(uri).path or uri,
+        }
+        if local_name(element.tag) == "Collection" and display_id == root_display_id:
+            collection = element
+
+    if collection is None:
+        raise ValueError(f"collection {root_display_id!r} is absent from SBOL download")
+
+    member_uris = [
+        child.get(RDF_RESOURCE)
+        for child in collection
+        if local_name(child.tag) == "member" and child.get(RDF_RESOURCE)
+    ]
+    collection_segment = f"/{collection_id}/"
+    candidates = sorted(
+        (
+            descriptions[uri]
+            for uri in member_uris
+            if uri in descriptions
+            and descriptions[uri]["display_id"]
+            and collection_segment in descriptions[uri]["uri_path"]
+            and descriptions[uri]["display_id"] != root_display_id
+        ),
+        key=lambda member: (
+            member["display_id"],
+            member["uri_path"],
+            member["type"],
+        ),
+    )
+    preferred = None
+    if source_display_id:
+        preferred = next(
+            (
+                member
+                for member in candidates
+                if member["display_id"] == source_display_id
+                or member["display_id"].endswith(f"_{source_display_id}")
+            ),
+            None,
+        )
+    selected = preferred or (candidates[0] if candidates else None)
+    return {
+        "member_reference_count": len(member_uris),
+        "probeable_member_count": len(candidates),
+        "source_display_id": source_display_id,
+        "selection": (
+            "source-display-id"
+            if preferred is not None
+            else "deterministic-direct-member" if selected is not None else None
+        ),
+        "selected": selected,
+    }
+
+
+def discover_imported_member(
+    client: Client,
+    token: str,
+    username: str,
+    collection_id: str,
+    source_display_id: str | None,
+) -> dict[str, object]:
+    path = (
+        f"/user/{urllib.parse.quote(username, safe='')}/{collection_id}/"
+        f"{collection_id}_collection/1/sbol"
+    )
+    response = client.request(
+        "GET", path, headers=token_headers(token, "application/rdf+xml")
+    )
+    evidence: dict[str, object] = {
+        "path": path,
+        "status": response.status,
+        "bytes": len(response.body),
+        "sha256": hashlib.sha256(response.body).hexdigest(),
+        "passed": False,
+    }
+    if response.status != 200:
+        evidence["error"] = f"HTTP {response.status}: {response.text[:500]}"
+        return evidence
+    try:
+        evidence.update(
+            parse_collection_oracle(response.body, collection_id, source_display_id)
+        )
+    except (ET.ParseError, ValueError) as error:
+        evidence["error"] = str(error)
+        return evidence
+    evidence["passed"] = True
+    return evidence
+
+
+def search(
+    client: Client,
+    term: str,
+    token: str | None,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, object]:
+    encoded = urllib.parse.quote(term, safe="")
+    suffix = "?" + urllib.parse.urlencode({"limit": limit, "offset": offset})
+    response = client.request(
+        "GET",
+        f"/search/{encoded}{suffix}",
+        headers=token_headers(token, "application/json"),
+    )
+    results, error = normalized_results(response)
+    count_response = client.request(
+        "GET", f"/searchCount/{encoded}{suffix}", headers=token_headers(token)
+    )
+    count: int | None = None
+    if count_response.status == 200:
+        try:
+            count = int(count_response.text.strip())
+        except ValueError:
+            pass
+    return {
+        "term": term,
+        "offset": offset,
+        "limit": limit,
+        "status": response.status,
+        "count_status": count_response.status,
+        "count": count,
+        "results": results,
+        "error": error,
+    }
+
+
+def completed_rebuilds(metrics_url: str | None, timeout: float) -> float | None:
+    if not metrics_url:
+        return None
+    try:
+        with urllib.request.urlopen(metrics_url, timeout=timeout) as response:
+            metrics = response.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError):
+        return None
+    total = 0.0
+    found = False
+    for line in metrics.splitlines():
+        if not line.startswith("sbol_db_jobs_completed_total{"):
+            continue
+        if 'kind="rebuild_search_index"' not in line or 'status="succeeded"' not in line:
+            continue
+        try:
+            total += float(line.rsplit(" ", 1)[1])
+            found = True
+        except (IndexError, ValueError):
+            continue
+    return total if found else 0.0
+
+
+def trigger_and_wait_for_index(
+    client: Client,
+    token: str,
+    metrics_url: str | None,
+    timeout: float,
+    poll_interval: float,
+) -> dict[str, object]:
+    baseline_metrics = completed_rebuilds(metrics_url, client.timeout)
+    before = client.request(
+        "GET", "/admin/explorerIndexingLog", headers=token_headers(token)
+    )
+    baseline_completions = before.text.count("INDEXING COMPLETED")
+    trigger = client.request(
+        "POST", "/admin/explorerUpdateIndex", headers=token_headers(token), fields={}
+    )
+    started = time.monotonic()
+    observation = None
+    while time.monotonic() - started < timeout:
+        current_metrics = completed_rebuilds(metrics_url, client.timeout)
+        if (
+            baseline_metrics is not None
+            and current_metrics is not None
+            and current_metrics > baseline_metrics
+        ):
+            observation = "sbol-db completed-job metric advanced"
+            break
+        log = client.request(
+            "GET", "/admin/explorerIndexingLog", headers=token_headers(token)
+        )
+        if log.status == 200 and log.text.count("INDEXING COMPLETED") > baseline_completions:
+            observation = "SBOLExplorer indexing log completed"
+            break
+        time.sleep(poll_interval)
+    return {
+        "trigger_status": trigger.status,
+        "trigger_body": trigger.text[:500],
+        "baseline_completed_rebuilds": baseline_metrics,
+        "baseline_log_completions": baseline_completions,
+        "observation": observation,
+        "elapsed_seconds": round(time.monotonic() - started, 3),
+        "passed": trigger.status == 200 and observation is not None,
+    }
+
+
+def result_has_display_id(probe: dict[str, object], display_id: str) -> bool:
+    return any(row.get("displayId") == display_id for row in probe["results"])
+
+
+def result_has_imported_member(
+    probe: dict[str, object], expected_member: dict[str, str]
+) -> bool:
+    return any(
+        row.get("uri_path") == expected_member["uri_path"]
+        and row.get("displayId") == expected_member["display_id"]
+        for row in probe["results"]
+    )
+
+
+def find_imported_member(
+    client: Client,
+    token: str,
+    expected_member: dict[str, str],
+    *,
+    window: int,
+    page_size: int = 50,
+) -> dict[str, object]:
+    """Page through a bounded result window without bloating the report.
+
+    ``results`` remains the first page used for backend parity comparison. A
+    later exact submission-member match is recorded separately in
+    ``matched_result`` with the amount of the ranked window examined.
+    """
+    term = expected_member["display_id"]
+    first_limit = min(page_size, window)
+    probe = search(client, term, token, limit=first_limit)
+    pages_scanned = 1
+    scanned_results = len(probe["results"])
+    matching = next(
+        (
+            row
+            for row in probe["results"]
+            if result_has_imported_member({"results": [row]}, expected_member)
+        ),
+        None,
+    )
+
+    count = probe.get("count")
+    ceiling = min(window, count) if isinstance(count, int) else window
+    offset = first_limit
+    encoded = urllib.parse.quote(term, safe="")
+    while matching is None and offset < ceiling:
+        limit = min(page_size, ceiling - offset)
+        suffix = "?" + urllib.parse.urlencode({"limit": limit, "offset": offset})
+        response = client.request(
+            "GET",
+            f"/search/{encoded}{suffix}",
+            headers=token_headers(token, "application/json"),
+        )
+        page, error = normalized_results(response)
+        pages_scanned += 1
+        scanned_results += len(page)
+        if error is not None:
+            probe["error"] = f"paged search at offset {offset}: {error}"
+            break
+        matching = next(
+            (
+                row
+                for row in page
+                if result_has_imported_member({"results": [row]}, expected_member)
+            ),
+            None,
+        )
+        if len(page) < limit:
+            break
+        offset += limit
+
+    probe["pages_scanned"] = pages_scanned
+    probe["scanned_results"] = scanned_results
+    probe["matched_result"] = matching
+    probe["expected_found"] = matching is not None
+    return probe
+
+
+def run_lifecycle(
+    client: Client,
+    token: str,
+    corpus_root: Path,
+    args: argparse.Namespace,
+) -> dict[str, object]:
+    source = corpus_root / "SBOL2/BBa_I0462.xml"
+    private_id = "search_acl_private"
+    submitted = submit(client, token, source, private_id)
+    first_index = trigger_and_wait_for_index(
+        client, token, args.metrics_url, args.index_timeout, args.poll_interval
+    )
+    private_auth = search(client, "BBa_I0462", token)
+    private_anon = search(client, "BBa_I0462", None)
+
+    made_public = client.request(
+        "POST",
+        f"/user/{args.username}/{private_id}/{private_id}_collection/1/makePublic",
+        headers=token_headers(token),
+        fields={
+            "tabState": "new",
+            "id": "search_acl_public",
+            "version": "1",
+            "name": "search ACL public",
+            "description": "public visibility probe",
+            "citations": "",
+        },
+    )
+    second_index = trigger_and_wait_for_index(
+        client, token, args.metrics_url, args.index_timeout, args.poll_interval
+    )
+    public_anon = search(client, "BBa_I0462", None)
+
+    remove_source = corpus_root / "SBOL2/Measure.xml"
+    remove_probe_id = probe_display_id(remove_source)
+    remove_id = "search_remove_private"
+    remove_submit = submit(client, token, remove_source, remove_id)
+    third_index = trigger_and_wait_for_index(
+        client, token, args.metrics_url, args.index_timeout, args.poll_interval
+    )
+    before_remove = search(client, remove_probe_id or "Measure", token)
+    removed = client.request(
+        "GET",
+        f"/user/{args.username}/{remove_id}/{remove_id}_collection/1/removeCollection",
+        headers=token_headers(token),
+    )
+    fourth_index = trigger_and_wait_for_index(
+        client, token, args.metrics_url, args.index_timeout, args.poll_interval
+    )
+    after_remove = search(client, remove_probe_id or "Measure", token)
+    remove_prefix = f"/user/{args.username}/{remove_id}/"
+    before_paths = {str(row["uri_path"]) for row in before_remove["results"]}
+    after_paths = {str(row["uri_path"]) for row in after_remove["results"]}
+    removed_paths = {path for path in before_paths if remove_prefix in path}
+
+    checks = {
+        "private_visible_to_owner": result_has_display_id(private_auth, "BBa_I0462"),
+        "private_hidden_from_anonymous": not result_has_display_id(
+            private_anon, "BBa_I0462"
+        ),
+        "public_visible_to_anonymous": result_has_display_id(public_anon, "BBa_I0462"),
+        "removed_collection_was_indexed": bool(removed_paths),
+        "removed_collection_disappeared": removed_paths.isdisjoint(after_paths),
+        "all_index_transitions_observed": all(
+            step["passed"]
+            for step in (first_index, second_index, third_index, fourth_index)
+        ),
+    }
+    return {
+        "submit_private_status": submitted.status,
+        "make_public_status": made_public.status,
+        "submit_remove_status": remove_submit.status,
+        "remove_status": removed.status,
+        "index_transitions": [first_index, second_index, third_index, fourth_index],
+        "private_authenticated": private_auth,
+        "private_anonymous": private_anon,
+        "public_anonymous": public_anon,
+        "before_remove": before_remove,
+        "after_remove": after_remove,
+        "checks": checks,
+        "passed": all(checks.values())
+        and submitted.status == 200
+        and made_public.status == 200
+        and remove_submit.status == 200
+        and removed.status == 200,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--topology", required=True)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--metrics-url")
+    parser.add_argument(
+        "--corpus-root",
+        type=Path,
+        default=Path.home() / "git/SynBioDex/SBOLTestSuite",
+    )
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument(
+        "--reprobe-from",
+        type=Path,
+        help="reuse submissions, lifecycle, and index evidence from a prior report",
+    )
+    parser.add_argument("--username", default="testuser")
+    parser.add_argument("--email", default="test@user.synbiohub")
+    parser.add_argument("--password", default="test")
+    parser.add_argument("--request-timeout", type=float, default=1800)
+    parser.add_argument("--index-timeout", type=float, default=3600)
+    parser.add_argument("--poll-interval", type=float, default=5)
+    parser.add_argument("--probe-window", type=int, default=10_000)
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument("--skip-lifecycle", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.probe_window <= 0:
+        raise SystemExit("--probe-window must be greater than zero")
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    if args.topology not in manifest["topologies"]:
+        raise SystemExit(f"unknown topology {args.topology!r}")
+    expected_revision = manifest["corpus"]["revision"]
+    actual_revision = git_revision(args.corpus_root)
+    if actual_revision != expected_revision:
+        raise SystemExit(
+            f"SBOLTestSuite revision drift: expected {expected_revision}, got {actual_revision}"
+        )
+
+    discovered = corpus_files(args.corpus_root, manifest["corpus"]["directories"])
+    selected = (
+        [args.corpus_root / relative for relative in SMOKE_PATHS]
+        if args.smoke
+        else discovered
+    )
+    client = Client(args.base_url, args.request_timeout)
+    token = ensure_setup(client, args)
+
+    reprobed_from_run_id = None
+    if args.reprobe_from:
+        prior = json.loads(args.reprobe_from.read_text())
+        expected_mode = "smoke" if args.smoke else "full"
+        if prior.get("topology") != args.topology or prior.get("mode") != expected_mode:
+            raise SystemExit("reprobe report topology or mode does not match this run")
+        prior_corpus = prior.get("corpus", {})
+        if (
+            prior_corpus.get("revision") != actual_revision
+            or prior_corpus.get("selected_xml_documents") != len(selected)
+        ):
+            raise SystemExit("reprobe report corpus does not match the pinned selection")
+        lifecycle = prior["lifecycle"]
+        submissions = prior["submissions"]
+        final_index = prior["final_index"]
+        transport_errors = list(prior.get("transport_errors", []))
+        reprobed_from_run_id = prior.get("run_id")
+    else:
+        lifecycle = (
+            {"skipped": True, "passed": False}
+            if args.skip_lifecycle
+            else run_lifecycle(client, token, args.corpus_root, args)
+        )
+        submissions = []
+        transport_errors = []
+        for index, path in enumerate(selected):
+            relative = path.relative_to(args.corpus_root).as_posix()
+            digest = sha256(path)
+            entry: dict[str, object] = {
+                "path": relative,
+                "sha256": digest,
+                "bytes": path.stat().st_size,
+                "source_probe_display_id": probe_display_id(path),
+                "collection_id": f"corpus_{index:04d}_{digest[:8]}",
+            }
+            try:
+                response = submit(client, token, path, str(entry["collection_id"]))
+                entry.update(
+                    {
+                        "status": response.status,
+                        "accepted": response.status == 200,
+                        "response": response.text[:1000],
+                    }
+                )
+            except (urllib.error.URLError, TimeoutError, OSError) as error:
+                entry.update(
+                    {"status": None, "accepted": False, "transport_error": str(error)}
+                )
+                transport_errors.append({"path": relative, "error": str(error)})
+            submissions.append(entry)
+            print(
+                f"[{index + 1}/{len(selected)}] {relative}: {entry.get('status')}",
+                flush=True,
+            )
+
+        final_index = trigger_and_wait_for_index(
+            client, token, args.metrics_url, args.index_timeout, args.poll_interval
+        )
+    probes = []
+    for entry in submissions:
+        if not entry.get("accepted"):
+            continue
+        source_display_id = entry.get(
+            "source_probe_display_id", entry.get("probe_display_id")
+        )
+        try:
+            oracle = discover_imported_member(
+                client,
+                token,
+                args.username,
+                str(entry["collection_id"]),
+                str(source_display_id) if source_display_id else None,
+            )
+            entry["collection_oracle"] = oracle
+            expected_member = oracle.get("selected")
+            if not isinstance(expected_member, dict):
+                continue
+            probe = find_imported_member(
+                client,
+                token,
+                expected_member,
+                window=args.probe_window,
+            )
+            probe["path"] = entry["path"]
+            probe["source_display_id"] = source_display_id
+            probe["expected_member"] = expected_member
+            probe["collection_id"] = entry["collection_id"]
+            probes.append(probe)
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            transport_errors.append({"path": entry["path"], "error": str(error)})
+
+    accepted_with_probe = [
+        entry
+        for entry in submissions
+        if entry.get("accepted")
+        and isinstance(entry.get("collection_oracle"), dict)
+        and isinstance(entry["collection_oracle"].get("selected"), dict)
+    ]
+    accepted = [entry for entry in submissions if entry.get("accepted")]
+    full_coverage = not args.smoke and len(selected) == len(discovered)
+    checks = {
+        "full_corpus_coverage": full_coverage,
+        "pinned_corpus_revision": actual_revision == expected_revision,
+        "no_transport_errors": not transport_errors,
+        "lifecycle_acl_and_removal": lifecycle.get("passed") is True,
+        "final_index_completion_observed": final_index["passed"],
+        "all_collection_oracles_succeeded": all(
+            isinstance(entry.get("collection_oracle"), dict)
+            and entry["collection_oracle"].get("passed") is True
+            for entry in accepted
+        ),
+        "one_probe_per_accepted_probeable_document": len(probes)
+        == len(accepted_with_probe),
+        "all_expected_imported_members_found": all(
+            probe["expected_found"] for probe in probes
+        ),
+        "all_probe_requests_succeeded": all(
+            probe["status"] == 200
+            and probe["count_status"] == 200
+            and probe["error"] is None
+            for probe in probes
+        ),
+    }
+    required = bool(manifest["topologies"][args.topology]["required"])
+    report = {
+        "schema_version": 2,
+        "run_id": str(uuid.uuid4()),
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "topology": args.topology,
+        "topology_contract": manifest["topologies"][args.topology],
+        "required": required,
+        "mode": "smoke" if args.smoke else "full",
+        "base_url": client.base_url,
+        "metrics_url": args.metrics_url,
+        "probe_window": args.probe_window,
+        "reprobed_from_run_id": reprobed_from_run_id,
+        "corpus": {
+            "revision": actual_revision,
+            "expected_revision": expected_revision,
+            "directories": manifest["corpus"]["directories"],
+            "discovered_xml_documents": len(discovered),
+            "selected_xml_documents": len(selected),
+            "manifest_sha256": hashlib.sha256(
+                "".join(sha256(path) for path in discovered).encode()
+            ).hexdigest(),
+        },
+        "lifecycle": lifecycle,
+        "submissions": submissions,
+        "final_index": final_index,
+        "probes": probes,
+        "transport_errors": transport_errors,
+        "gate": {"checks": checks, "passed": all(checks.values())},
+    }
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(report["gate"], indent=2, sort_keys=True))
+    # Diagnostic baselines always report their evidence without blocking CI.
+    return 1 if required and not report["gate"]["passed"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/search-backends/test_compare_reports.py
+++ b/tests/search-backends/test_compare_reports.py
@@ -1,0 +1,46 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("compare-reports.py")
+SPEC = importlib.util.spec_from_file_location("compare_reports", MODULE_PATH)
+compare_reports = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(compare_reports)
+
+
+class ParityPolicyTest(unittest.TestCase):
+    def test_accepts_current_compatibility_boundary(self):
+        summary = {
+            "compared_probe_count": 284,
+            "exact_first_page_parity_count": 261,
+            "submission_difference_count": 0,
+            "count_difference_count": 2,
+        }
+        differences = [
+            {"baseline_count": 3, "candidate_count": 4},
+            {"baseline_count": 3, "candidate_count": 4},
+        ]
+
+        gate = compare_reports.evaluate_parity(True, True, True, summary, differences)
+
+        self.assertTrue(gate["passed"])
+        self.assertEqual(gate["observed"]["maximum_count_delta"], 1)
+
+    def test_rejects_tokenizer_style_count_explosion(self):
+        summary = {
+            "compared_probe_count": 284,
+            "exact_first_page_parity_count": 109,
+            "submission_difference_count": 0,
+            "count_difference_count": 170,
+        }
+        differences = [{"baseline_count": 1, "candidate_count": 10000}]
+
+        gate = compare_reports.evaluate_parity(True, True, True, summary, differences)
+
+        self.assertFalse(gate["passed"])
+        self.assertFalse(gate["checks"]["maximum_count_delta_at_most_1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/search-backends/test_run_conformance.py
+++ b/tests/search-backends/test_run_conformance.py
@@ -1,0 +1,72 @@
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("run-conformance.py")
+SPEC = importlib.util.spec_from_file_location("search_backend_conformance", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+CONFORMANCE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CONFORMANCE
+SPEC.loader.exec_module(CONFORMANCE)
+
+
+class CollectionOracleTest(unittest.TestCase):
+    def test_selects_rewritten_direct_member_and_ignores_external_reference(self):
+        body = b"""<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:sbol="http://sbols.org/v2#"
+         xmlns:grn="http://example.org/grn#">
+  <sbol:Collection rdf:about="http://example.test/user/test/corpus_0001/corpus_0001_collection/1">
+    <sbol:displayId>corpus_0001_collection</sbol:displayId>
+    <sbol:member rdf:resource="http://example.test/user/test/corpus_0001/ComponentDefinition_design/1"/>
+    <sbol:member rdf:resource="https://external.example/part/1"/>
+  </sbol:Collection>
+  <sbol:ComponentDefinition rdf:about="http://example.test/user/test/corpus_0001/ComponentDefinition_design/1">
+    <sbol:displayId>ComponentDefinition_design</sbol:displayId>
+  </sbol:ComponentDefinition>
+  <grn:RegulatoryReaction rdf:about="https://external.example/part/1">
+    <sbol:displayId>external_part</sbol:displayId>
+  </grn:RegulatoryReaction>
+</rdf:RDF>
+"""
+
+        oracle = CONFORMANCE.parse_collection_oracle(body, "corpus_0001", "design")
+
+        self.assertEqual(oracle["member_reference_count"], 2)
+        self.assertEqual(oracle["probeable_member_count"], 1)
+        self.assertEqual(oracle["selection"], "source-display-id")
+        self.assertEqual(
+            oracle["selected"],
+            {
+                "display_id": "ComponentDefinition_design",
+                "type": "ComponentDefinition",
+                "uri_path": "/user/test/corpus_0001/ComponentDefinition_design/1",
+            },
+        )
+
+    def test_falls_back_deterministically_after_import_normalization(self):
+        body = b"""<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:sbol="http://sbols.org/v2#">
+  <sbol:Collection rdf:about="http://example.test/user/test/corpus_0002/corpus_0002_collection/1">
+    <sbol:displayId>corpus_0002_collection</sbol:displayId>
+    <sbol:member rdf:resource="http://example.test/user/test/corpus_0002/urn_z/1"/>
+    <sbol:member rdf:resource="http://example.test/user/test/corpus_0002/urn_a/1"/>
+  </sbol:Collection>
+  <sbol:ComponentDefinition rdf:about="http://example.test/user/test/corpus_0002/urn_z/1">
+    <sbol:displayId>urn_z</sbol:displayId>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://example.test/user/test/corpus_0002/urn_a/1">
+    <sbol:displayId>urn_a</sbol:displayId>
+  </sbol:ComponentDefinition>
+</rdf:RDF>"""
+
+        oracle = CONFORMANCE.parse_collection_oracle(body, "corpus_0002", "rbsB")
+
+        self.assertEqual(oracle["selection"], "deterministic-direct-member")
+        self.assertEqual(oracle["selected"]["display_id"], "urn_a")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/start_containers.sh
+++ b/tests/start_containers.sh
@@ -8,26 +8,31 @@ fi
 
 source ./testutil.sh
 
-message "Cleaning old test containers if they exist"
-
-bash ./testcleanup.sh
-
-
-message "pulling synbiohub/synbiohub-docker"
-if cd synbiohub-docker; then
-    git checkout snapshot;
-    git pull;
-    cd ..;
+if [[ "$SBH_DOCKER_DIR" == "./synbiohub-docker" ]]; then
+    message "pulling synbiohub/synbiohub-docker"
+    if cd synbiohub-docker; then
+        git checkout snapshot;
+        git pull;
+        cd ..;
+    else
+        # Clone the compose files when no explicit checkout was supplied.
+        git clone --single-branch --branch snapshot https://github.com/synbiohub/synbiohub-docker
+    fi
 else
-    # clone the synbiohub docker compose file in order to run docker containers
-    git clone --single-branch --branch snapshot https://github.com/synbiohub/synbiohub-docker
+    message "Using SynBioHub Docker checkout: $SBH_DOCKER_DIR"
 fi
 
-if [[ "$SBH_TRIPLESTORE" == "sboldb" && ! -f ./synbiohub-docker/docker-compose.sboldb.yml ]]; then
-    message "docker-compose.sboldb.yml not found in the synbiohub-docker checkout."
-    message "It lives in the synbiohub-docker repo; update that checkout to a revision that has it."
-    exit 1
-fi
+COMPOSE_FILES=$(backend_compose_files) || exit 1
+for compose_file in $(echo "$COMPOSE_FILES" | sed 's/-f //g'); do
+    if [[ ! -f "$compose_file" ]]; then
+        message "Required compose file not found: $compose_file"
+        message "Update the synbiohub-docker checkout, or set SBH_DOCKER_DIR to the comparison branch checkout."
+        exit 1
+    fi
+done
+
+message "Cleaning old test containers if they exist"
+bash ./testcleanup.sh
 
 
 bash ./start_containers_persist.sh "$SBH_TRIPLESTORE"

--- a/tests/start_containers_persist.sh
+++ b/tests/start_containers_persist.sh
@@ -9,9 +9,9 @@ fi
 
 source ./testutil.sh
 
-COMPOSE_FILES=$(triplestore_compose_files) || exit 1
+COMPOSE_FILES=$(backend_compose_files) || exit 1
 
-message "Starting SynBioHub from Containers (triplestore: $SBH_TRIPLESTORE)"
+message "Starting SynBioHub from Containers (store: $SBH_TRIPLESTORE, search: $SBH_SEARCH_BACKEND)"
 docker compose $COMPOSE_FILES -p testsuiteproject --compatibility up -d
 while [[ "$(docker inspect testsuiteproject_synbiohub_1 | jq .[0].State.Health.Status)" != "\"healthy\"" ]]
 do

--- a/tests/stop_containers.sh
+++ b/tests/stop_containers.sh
@@ -2,9 +2,9 @@
 
 source ./testutil.sh
 
-COMPOSE_FILES=$(triplestore_compose_files) || exit 1
+COMPOSE_FILES=$(backend_compose_files) || exit 1
 
 # Stop (do not remove) the containers, leaving volumes intact so the persistence
 # phase can restart the same stack with its data.
-message "Stopping containers (triplestore: $SBH_TRIPLESTORE)"
+message "Stopping containers (store: $SBH_TRIPLESTORE, search: $SBH_SEARCH_BACKEND)"
 docker compose $COMPOSE_FILES -p testsuiteproject stop

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,10 +5,12 @@ cd tests
 source ./testutil.sh
 
 # Run the whole stack (initial bring-up, persistence restart, SBOLTestRunner)
-# against one triplestore. Defaults to virtuoso; set SBH_TRIPLESTORE=sboldb to
-# run the identical suite and fixtures against sbol-db.
+# against one store/search pairing. Search defaults to none for the historical
+# suite. Set SBH_SEARCH_BACKEND=external to test SBOLExplorer, or use native
+# with SBH_TRIPLESTORE=sboldb to test sbol-db in both roles.
 export SBH_TRIPLESTORE
-message "Triplestore backend: $SBH_TRIPLESTORE"
+export SBH_SEARCH_BACKEND
+message "Backends: store=$SBH_TRIPLESTORE search=$SBH_SEARCH_BACKEND"
 
 # first, if it was run with help, just run the test script with help
 if [[ "$@" == "--help" || "$@" == "-h" ]]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -6,8 +6,8 @@ source ./testutil.sh
 
 # Run the whole stack (initial bring-up, persistence restart, SBOLTestRunner)
 # against one store/search pairing. Search defaults to none for the historical
-# suite. Set SBH_SEARCH_BACKEND=external to test SBOLExplorer, or use native
-# with SBH_TRIPLESTORE=sboldb to test sbol-db in both roles.
+# suite. Set SBH_SEARCH_BACKEND=sbol-explorer to test SBOLExplorer, or use
+# sbol-db with SBH_TRIPLESTORE=sboldb to test sbol-db in both roles.
 export SBH_TRIPLESTORE
 export SBH_SEARCH_BACKEND
 message "Backends: store=$SBH_TRIPLESTORE search=$SBH_SEARCH_BACKEND"

--- a/tests/test_explorer_search.py
+++ b/tests/test_explorer_search.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from test_arguments import test_print
+from test_functions import compare_get_request, refresh_explorer_index
+
+
+class TestExplorerSearch(TestCase):
+
+    def test_indexed_search_html(self):
+        """Index the fixture explicitly, then enforce SBH1's rendered result."""
+        test_print("test_explorer_indexed_search starting")
+        refresh_explorer_index("I0462", "BBa_I0462")
+        # Reuse the established whole-page snapshot. Explorer-enabled matrix
+        # rows run this focused contract instead of TestSearch, so the request
+        # path remains unique in the legacy TestState registry.
+        compare_get_request("/search/:query?", route_parameters=["I0462"])
+        test_print("test_explorer_indexed_search completed")

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,4 @@
-import subprocess, shutil, time, os
+import subprocess, shutil, time, os, re
 from requests.exceptions import HTTPError
 import requests_html, difflib, sys, requests, json
 from bs4 import BeautifulSoup
@@ -246,6 +246,126 @@ def login_with(data, headers = {'Accept':'text/plain'}):
     test_state.save_authentication(result)
 
 
+def refresh_explorer_index(query, expected_display_id):
+    """Trigger the configured Explorer and wait for one known indexed result.
+
+    The final user-visible contract is still checked by compare_get_request;
+    this helper makes that HTML snapshot deterministic without depending on a
+    backend-specific log format. Strict Explorer mode means search failures
+    cannot be satisfied by a triplestore fallback while this loop is running.
+    """
+    backend = os.environ.get("SBH_SEARCH_BACKEND", "none")
+    if backend == "none":
+        test_print("Search backend disabled; skipping explicit index refresh")
+        return
+    if backend not in ("external", "native"):
+        raise ValueError("Unknown SBH_SEARCH_BACKEND: " + backend)
+
+    token = test_state.get_authentication()
+    if token is None:
+        raise RuntimeError("Explorer index refresh requires an authenticated administrator")
+
+    headers = {
+        "Accept": "application/json",
+        "X-authorization": token,
+    }
+    config_response = requests.get(
+        args.serveraddress + "admin/explorer", headers=headers, timeout=30
+    )
+    config_response.raise_for_status()
+    explorer_config = config_response.json()
+    if explorer_config.get("useSBOLExplorer") is not True:
+        raise AssertionError(
+            "The test topology did not enable its Explorer endpoint: "
+            + json.dumps(explorer_config, sort_keys=True)
+        )
+
+    indexing_info_url = args.serveraddress + "admin/explorerIndexingLog"
+    try:
+        before_info_response = requests.get(indexing_info_url, headers=headers, timeout=30)
+        before_info_response.raise_for_status()
+        before_info = before_info_response.text
+    except requests.RequestException:
+        # A fresh external Explorer may not have created its log file yet.
+        before_info = ""
+    before_external_completions = before_info.count("Successfully updated index")
+    before_native_match = re.search(r"job_id=([^ ]+) status=([^ ]+)", before_info)
+    before_native_job = before_native_match.group(1) if before_native_match else None
+
+    update_response = requests.post(
+        args.serveraddress + "admin/explorerUpdateIndex",
+        headers={
+            "Accept": "text/plain",
+            "X-authorization": token,
+        },
+        timeout=30,
+    )
+    update_response.raise_for_status()
+
+    timeout_seconds = int(os.environ.get("SBH_EXPLORER_INDEX_TIMEOUT", "300"))
+    deadline = time.monotonic() + timeout_seconds
+    last_observation = "index request accepted; no lifecycle response observed"
+
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(indexing_info_url, headers=headers, timeout=30)
+            response.raise_for_status()
+            info = response.text
+            last_observation = info[-1000:]
+            native_match = re.search(r"job_id=([^ ]+) status=([^ ]+)", info)
+            if native_match and native_match.group(1) != before_native_job:
+                status = native_match.group(2)
+                if status == "succeeded":
+                    break
+                if status in ("failed", "cancelled", "dead"):
+                    raise AssertionError(
+                        "sbol-db index update reached terminal status " + status
+                        + ": " + info
+                    )
+            elif (
+                info.count("Successfully updated index")
+                > before_external_completions
+            ):
+                break
+        except requests.RequestException as error:
+            last_observation = repr(error)
+        time.sleep(2)
+    else:
+        raise AssertionError(
+            "Explorer indexing did not complete within " + str(timeout_seconds)
+            + " seconds; last lifecycle observation: " + last_observation
+        )
+
+    # Completion and visibility get independent bounds: a large index may use
+    # almost all of the lifecycle timeout, but publication into the completed
+    # index should become visible promptly afterward.
+    deadline = time.monotonic() + min(60, timeout_seconds)
+    search_url = args.serveraddress + "search/" + requests.utils.quote(query, safe="")
+    last_observation = "index completed; no search request attempted"
+
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(search_url, headers=headers, timeout=30)
+            last_observation = "HTTP " + str(response.status_code) + ": " + response.text[:500]
+            if response.ok:
+                results = response.json()
+                if any(row.get("displayId") == expected_display_id for row in results):
+                    test_print(
+                        "Explorer index contains " + expected_display_id
+                        + " (backend=" + backend + ")"
+                    )
+                    return
+        except (requests.RequestException, ValueError) as error:
+            last_observation = repr(error)
+        time.sleep(2)
+
+    raise AssertionError(
+        "Explorer indexing did not expose " + expected_display_id
+        + " within " + str(timeout_seconds) + " seconds; last observation: "
+        + last_observation
+    )
+
+
 def compare_get_request(request, test_name = "", route_parameters = [], headers = {}, re_render_time = 0):
     """Complete a get request and error if it differs from previous results.
 page
@@ -341,5 +461,3 @@ def copy_docker_log():
 
     run_bash("docker cp " + SBH_TEST_CONTAINER + ":/mnt/data/logs .")
     run_bash("mv ./logs ./logs_from_test_suite")
-
-

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -258,7 +258,7 @@ def refresh_explorer_index(query, expected_display_id):
     if backend == "none":
         test_print("Search backend disabled; skipping explicit index refresh")
         return
-    if backend not in ("external", "native"):
+    if backend not in ("sbol-explorer", "sbol-db"):
         raise ValueError("Unknown SBH_SEARCH_BACKEND: " + backend)
 
     token = test_state.get_authentication()
@@ -286,11 +286,11 @@ def refresh_explorer_index(query, expected_display_id):
         before_info_response.raise_for_status()
         before_info = before_info_response.text
     except requests.RequestException:
-        # A fresh external Explorer may not have created its log file yet.
+        # A fresh SBOLExplorer may not have created its log file yet.
         before_info = ""
-    before_external_completions = before_info.count("Successfully updated index")
-    before_native_match = re.search(r"job_id=([^ ]+) status=([^ ]+)", before_info)
-    before_native_job = before_native_match.group(1) if before_native_match else None
+    before_sbol_explorer_completions = before_info.count("Successfully updated index")
+    before_sbol_db_match = re.search(r"job_id=([^ ]+) status=([^ ]+)", before_info)
+    before_sbol_db_job = before_sbol_db_match.group(1) if before_sbol_db_match else None
 
     update_response = requests.post(
         args.serveraddress + "admin/explorerUpdateIndex",
@@ -312,9 +312,9 @@ def refresh_explorer_index(query, expected_display_id):
             response.raise_for_status()
             info = response.text
             last_observation = info[-1000:]
-            native_match = re.search(r"job_id=([^ ]+) status=([^ ]+)", info)
-            if native_match and native_match.group(1) != before_native_job:
-                status = native_match.group(2)
+            sbol_db_match = re.search(r"job_id=([^ ]+) status=([^ ]+)", info)
+            if sbol_db_match and sbol_db_match.group(1) != before_sbol_db_job:
+                status = sbol_db_match.group(2)
                 if status == "succeeded":
                     break
                 if status in ("failed", "cancelled", "dead"):
@@ -324,7 +324,7 @@ def refresh_explorer_index(query, expected_display_id):
                     )
             elif (
                 info.count("Successfully updated index")
-                > before_external_completions
+                > before_sbol_explorer_completions
             ):
                 break
         except requests.RequestException as error:

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -34,9 +34,17 @@ def test_root():
     testSubmit.test_submit()
 
     # no commented tests
-    from test_search import TestSearch
-    testSearch = TestSearch()
-    testSearch.test_search()
+    import os
+    if os.environ.get('SBH_SEARCH_BACKEND', 'none') == 'none':
+        from test_search import TestSearch
+        testSearch = TestSearch()
+        testSearch.test_search()
+    else:
+        # External SBOLExplorer and sbol-db's compatible listener share this
+        # exact user-visible contract: explicit indexing followed by the
+        # existing complete HTML snapshot for the known I0462 fixture.
+        from test_explorer_search import TestExplorerSearch
+        TestExplorerSearch().test_indexed_search_html()
 
     # TODO: TEST TEST_DOWNLOAD
     from test_download import TestDownload

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -40,7 +40,7 @@ def test_root():
         testSearch = TestSearch()
         testSearch.test_search()
     else:
-        # External SBOLExplorer and sbol-db's compatible listener share this
+        # SBOLExplorer and sbol-db's compatible listener share this
         # exact user-visible contract: explicit indexing followed by the
         # existing complete HTML snapshot for the known I0462 fixture.
         from test_explorer_search import TestExplorerSearch

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -64,4 +64,3 @@ class TestSearch(TestCase):
         compare_get_request("browse", headers = {"Accept": "text/html"})
         test_print("test_browse_get completed")
 
-

--- a/tests/testcleanup.sh
+++ b/tests/testcleanup.sh
@@ -2,12 +2,12 @@
 
 source ./testutil.sh
 
-# Tear down any leftover testsuiteproject stack from a previous run, whichever
-# triplestore it used. `down` finds the containers by project label, so it works
-# without knowing the compose file; the explicit volume removals below are a
-# best-effort fallback covering both backends' named volumes.
+# Tear down any leftover testsuiteproject stack from a previous run. Supplying
+# the selected files is required by modern Compose; --remove-orphans also
+# removes services left by a different store/search pairing under this project.
 message "Removing any existing testsuiteproject containers and volumes"
-docker compose -p testsuiteproject down --volumes --remove-orphans 2>/dev/null || true
+COMPOSE_FILES=$(backend_compose_files) || exit 1
+docker compose $COMPOSE_FILES -p testsuiteproject down --volumes --remove-orphans 2>/dev/null || true
 
 for volume in \
     testsuiteproject_esdata \

--- a/tests/testutil.sh
+++ b/tests/testutil.sh
@@ -3,24 +3,37 @@ function message {
 }
 
 # Triplestore backend the test stack runs against: "virtuoso" (default) or
-# "sboldb". Set with the SBH_TRIPLESTORE environment variable, or pass it as the
-# first argument to start_containers.sh / start_containers_persist.sh. The only
-# difference between the two is which docker-compose file describes the stack, so
-# the same SynBioHub image and the same fixtures gate both backends.
+# "sboldb". SBH_SEARCH_BACKEND independently selects "external" SBOLExplorer,
+# sbol-db's "native" compatibility listener, or "none". The historical full
+# suite stays store-only by default; external/native matrix rows opt in and run
+# the focused indexed-HTML contract in place of the ordinary search bundle.
 SBH_TRIPLESTORE="${SBH_TRIPLESTORE:-virtuoso}"
+SBH_SEARCH_BACKEND="${SBH_SEARCH_BACKEND:-none}"
+SBH_DOCKER_DIR="${SBH_DOCKER_DIR:-./synbiohub-docker}"
 
-# Echo the docker-compose -f flags for the selected triplestore. The compose
-# files live in the synbiohub-docker checkout that start_containers.sh clones.
-function triplestore_compose_files {
-    case "$SBH_TRIPLESTORE" in
-        virtuoso)
-            echo "-f ./synbiohub-docker/docker-compose.yml -f ./synbiohub-docker/docker-compose.explorer.yml"
+# Echo the Docker Compose files for the independently selected store/search
+# roles. The overlays set Explorer configuration at container startup and turn
+# fallback off, so a failed search backend cannot be hidden by the store.
+function backend_compose_files {
+    case "$SBH_TRIPLESTORE:$SBH_SEARCH_BACKEND" in
+        virtuoso:none)
+            echo "-f $SBH_DOCKER_DIR/docker-compose.yml"
             ;;
-        sboldb)
-            echo "-f ./synbiohub-docker/docker-compose.sboldb.yml"
+        virtuoso:external)
+            echo "-f $SBH_DOCKER_DIR/docker-compose.yml -f $SBH_DOCKER_DIR/docker-compose.explorer.yml"
+            ;;
+        sboldb:none)
+            echo "-f $SBH_DOCKER_DIR/docker-compose.sboldb.yml"
+            ;;
+        sboldb:external)
+            echo "-f $SBH_DOCKER_DIR/docker-compose.sboldb.yml -f $SBH_DOCKER_DIR/docker-compose.sboldb-store-only.yml -f $SBH_DOCKER_DIR/docker-compose.explorer.yml"
+            ;;
+        sboldb:native)
+            echo "-f $SBH_DOCKER_DIR/docker-compose.sboldb.yml -f $SBH_DOCKER_DIR/docker-compose.sboldb-search.yml"
             ;;
         *)
-            message "Unknown SBH_TRIPLESTORE '$SBH_TRIPLESTORE' (expected virtuoso or sboldb)." 1>&2
+            message "Unsupported backend pair store='$SBH_TRIPLESTORE' search='$SBH_SEARCH_BACKEND'." 1>&2
+            message "Expected virtuoso:(none|external) or sboldb:(none|external|native)." 1>&2
             return 1
             ;;
     esac

--- a/tests/testutil.sh
+++ b/tests/testutil.sh
@@ -3,10 +3,10 @@ function message {
 }
 
 # Triplestore backend the test stack runs against: "virtuoso" (default) or
-# "sboldb". SBH_SEARCH_BACKEND independently selects "external" SBOLExplorer,
-# sbol-db's "native" compatibility listener, or "none". The historical full
-# suite stays store-only by default; external/native matrix rows opt in and run
-# the focused indexed-HTML contract in place of the ordinary search bundle.
+# "sboldb". SBH_SEARCH_BACKEND independently selects "sbol-explorer",
+# "sbol-db", or "none". The historical full suite stays store-only by default;
+# the two named search-backend matrix rows opt in and run the focused
+# indexed-HTML contract in place of the ordinary search bundle.
 SBH_TRIPLESTORE="${SBH_TRIPLESTORE:-virtuoso}"
 SBH_SEARCH_BACKEND="${SBH_SEARCH_BACKEND:-none}"
 SBH_DOCKER_DIR="${SBH_DOCKER_DIR:-./synbiohub-docker}"
@@ -19,21 +19,21 @@ function backend_compose_files {
         virtuoso:none)
             echo "-f $SBH_DOCKER_DIR/docker-compose.yml"
             ;;
-        virtuoso:external)
+        virtuoso:sbol-explorer)
             echo "-f $SBH_DOCKER_DIR/docker-compose.yml -f $SBH_DOCKER_DIR/docker-compose.explorer.yml"
             ;;
         sboldb:none)
             echo "-f $SBH_DOCKER_DIR/docker-compose.sboldb.yml"
             ;;
-        sboldb:external)
+        sboldb:sbol-explorer)
             echo "-f $SBH_DOCKER_DIR/docker-compose.sboldb.yml -f $SBH_DOCKER_DIR/docker-compose.sboldb-store-only.yml -f $SBH_DOCKER_DIR/docker-compose.explorer.yml"
             ;;
-        sboldb:native)
+        sboldb:sbol-db)
             echo "-f $SBH_DOCKER_DIR/docker-compose.sboldb.yml -f $SBH_DOCKER_DIR/docker-compose.sboldb-search.yml"
             ;;
         *)
             message "Unsupported backend pair store='$SBH_TRIPLESTORE' search='$SBH_SEARCH_BACKEND'." 1>&2
-            message "Expected virtuoso:(none|external) or sboldb:(none|external|native)." 1>&2
+            message "Expected virtuoso:(none|sbol-explorer) or sboldb:(none|sbol-explorer|sbol-db)." 1>&2
             return 1
             ;;
     esac


### PR DESCRIPTION
## Summary

This PR makes SynBioHub's Explorer integration explicitly configurable and testable against both SBOLExplorer and compatible search backends.

- Adds runtime-only environment overrides for enabling Explorer, selecting its endpoint, and controlling fallback behavior.
- Adds a strict Explorer mode that surfaces backend failures instead of silently retrying the query against the triplestore.
- Lets the test harness select the store and search backends independently:
  - Virtuoso with no external search backend
  - Virtuoso with SBOLExplorer
  - sbol-db with no external search backend
  - sbol-db with SBOLExplorer
  - sbol-db with its SBOLExplorer-compatible listener
- Adds an Explorer-specific integration test that explicitly requests an index update, waits for that operation to complete, and compares the complete `/search/I0462` HTML against the established SynBioHub snapshot.
- Adds a pinned-corpus conformance harness for comparing submission, indexing, lifecycle, visibility, removal, and search behavior across Explorer implementations.
- Allows tests to use an explicit `SBH_DOCKER_DIR`, so the SynBioHub changes can be evaluated against an unmerged `synbiohub-docker` checkout.

## Compatibility

Normal SynBioHub behavior is unchanged unless the new environment overrides are supplied. Explorer fallback remains enabled by default, while the test harness uses explicit backend selections so an unavailable Explorer cannot be mistaken for a passing result.

The Explorer-enabled test rows are opt-in and use the companion `synbiohub-docker` topology changes.

## Testing

- The GitHub Integration testing workflow passes for this branch.
- The conformance runner and report-comparison unit tests pass:

  `python3 -m unittest tests/search-backends/test_run_conformance.py tests/search-backends/test_compare_reports.py`