### PR TITLE
Use synbiohub-docker snapshot in CI

### DIFF
--- a/.github/workflows/search-backend-conformance.yml
+++ b/.github/workflows/search-backend-conformance.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SYNBIOHUB_DOCKER_REF: marpaia/sbol-db-and-explorer
+  SYNBIOHUB_DOCKER_REF: snapshot
   SBOL_TEST_SUITE_REVISION: 0044284331b2f915a6e4b9d50e1cbf3ea2f62dcd
   SYNBIOHUB_CONFORMANCE_IMAGE: synbiohub/synbiohub:search-conformance
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Integration testing
 on: push
 
 env:
-  SYNBIOHUB_DOCKER_REF: marpaia/sbol-db-and-explorer
+  SYNBIOHUB_DOCKER_REF: snapshot
 
 jobs:
   build:


### PR DESCRIPTION
Summary:
- point the integration and search-conformance workflows at the maintained synbiohub-docker snapshot branch
- consume the v0.1.3 sbol-db defaults merged in SynBioHub/synbiohub-docker#28
- remove the stale dependency on the deleted marpaia/sbol-db-and-explorer branch

This addresses both failure modes in master run 30647783848: the Explorer matrix can check out its Docker topology again, and the store-only sbol-db job reruns against v0.1.3 with literal SPARQL as the default behavior.

Local validation:
- python3 -m unittest tests/search-backends/test_run_conformance.py tests/search-backends/test_compare_reports.py
- git diff --check

The decisive gate is this PR's full Integration testing workflow.